### PR TITLE
Convert ScEntity to QuickJS

### DIFF
--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -1108,6 +1108,7 @@
     <ClCompile Include="scenes\title\TitleSequence.cpp" />
     <ClCompile Include="scenes\title\TitleSequenceManager.cpp" />
     <ClCompile Include="scripting\bindings\entity\ScBalloon.cpp" />
+    <ClCompile Include="scripting\bindings\entity\ScEntity.cpp" />
     <ClCompile Include="scripting\bindings\entity\ScGuest.cpp" />
     <ClCompile Include="scripting\bindings\entity\ScLitter.cpp" />
     <ClCompile Include="scripting\bindings\entity\ScMoneyEffect.cpp" />

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -453,6 +453,7 @@ ScConsole Scripting::gScConsole;
 ScContext Scripting::gScContext;
 ScDisposable Scripting::gScDisposable;
 ScNetwork Scripting::gScNetwork;
+ScEntity Scripting::gScEntity;
 
 void ScriptEngine::RegisterClasses(JSContext* ctx)
 {
@@ -493,7 +494,7 @@ void ScriptEngine::RegisterClasses(JSContext* ctx)
     // ScTileElement::Register(ctx);
     // ScTrackIterator::Register(ctx);
     // ScTrackSegment::Register(ctx);
-    // ScEntity::Register(ctx);
+    gScEntity.Register(ctx);
     // ScLitter::Register(ctx);
     // ScBalloon::Register(ctx);
     // ScMoneyEffect::Register(ctx);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -495,8 +495,6 @@ void ScriptEngine::RegisterClasses(JSContext* ctx)
     // ScTrackIterator::Register(ctx);
     // ScTrackSegment::Register(ctx);
     gScEntity.Register(ctx);
-    // ScLitter::Register(ctx);
-    // ScBalloon::Register(ctx);
     // ScMoneyEffect::Register(ctx);
     // ScVehicle::Register(ctx);
     // ScCrashedVehicleParticle::Register(ctx);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -454,6 +454,7 @@ ScContext Scripting::gScContext;
 ScDisposable Scripting::gScDisposable;
 ScNetwork Scripting::gScNetwork;
 ScEntity Scripting::gScEntity;
+ScThought Scripting::gScThought;
 ScPatrolArea Scripting::gScPatrolArea;
 
 void ScriptEngine::RegisterClasses(JSContext* ctx)
@@ -501,7 +502,7 @@ void ScriptEngine::RegisterClasses(JSContext* ctx)
     // ScCrashedVehicleParticle::Register(ctx);
     // ScPeep::Register(ctx);
     // ScGuest::Register(ctx);
-    // ScThought::Register(ctx);
+    gScThought.Register(ctx);
     // #ifndef DISABLE_NETWORK
     // ScSocket::Register(ctx);
     // ScListener::Register(ctx);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -454,6 +454,7 @@ ScContext Scripting::gScContext;
 ScDisposable Scripting::gScDisposable;
 ScNetwork Scripting::gScNetwork;
 ScEntity Scripting::gScEntity;
+ScPatrolArea Scripting::gScPatrolArea;
 
 void ScriptEngine::RegisterClasses(JSContext* ctx)
 {
@@ -507,7 +508,7 @@ void ScriptEngine::RegisterClasses(JSContext* ctx)
     // #endif
     // ScScenario::Register(ctx);
     // ScScenarioObjective::Register(ctx);
-    // ScPatrolArea::Register(ctx);
+    gScPatrolArea.Register(ctx);
     // ScStaff::Register(ctx);
     // ScHandyman::Register(ctx);
     // ScMechanic::Register(ctx);

--- a/src/openrct2/scripting/ScriptUtil.hpp
+++ b/src/openrct2/scripting/ScriptUtil.hpp
@@ -354,6 +354,18 @@ namespace OpenRCT2::Scripting
             return JS_EXCEPTION;                                                                                               \
         }
 
+    #define JS_UNPACK_INT64(var, ctx, val)                                                                                     \
+        int64_t var;                                                                                                           \
+        if (!JS_IsNumber(val))                                                                                                 \
+        {                                                                                                                      \
+            JS_ThrowTypeError(ctx, "Expected number");                                                                         \
+            return JS_EXCEPTION;                                                                                               \
+        }                                                                                                                      \
+        if (JS_ToInt64(ctx, &var, val) < 0)                                                                                    \
+        {                                                                                                                      \
+            return JS_EXCEPTION;                                                                                               \
+        }
+
     #define JS_UNPACK_UINT32(var, ctx, val)                                                                                    \
         uint32_t var;                                                                                                          \
         if (!JS_IsNumber(val))                                                                                                 \

--- a/src/openrct2/scripting/ScriptUtil.hpp
+++ b/src/openrct2/scripting/ScriptUtil.hpp
@@ -168,6 +168,22 @@ namespace OpenRCT2::Scripting
         return output;
     }
 
+    inline std::optional<uint32_t> JSToOptionalUint(JSContext* ctx, JSValue obj, const char* property)
+    {
+        JSValue val = JS_GetPropertyStr(ctx, obj, property);
+        std::optional<uint32_t> output = std::nullopt;
+        if (JS_IsNumber(val))
+        {
+            uint32_t uintVal = 0;
+            if (JS_ToUint32(ctx, &uintVal, val) >= 0)
+            {
+                output = std::make_optional(uintVal);
+            }
+        }
+        JS_FreeValue(ctx, val);
+        return output;
+    }
+
     inline bool AsOrDefault(JSContext* ctx, JSValue obj, const char* property, bool def)
     {
         JSValue val = JS_GetPropertyStr(ctx, obj, property);

--- a/src/openrct2/scripting/ScriptUtil.hpp
+++ b/src/openrct2/scripting/ScriptUtil.hpp
@@ -278,6 +278,33 @@ namespace OpenRCT2::Scripting
         return output;
     }
 
+    inline uint32_t JSToUint(JSContext* ctx, JSValue val)
+    {
+        uint32_t output = 0;
+        if (JS_IsNumber(val))
+        {
+            JS_ToUint32(ctx, &output, val);
+        }
+        return output;
+    }
+
+    inline uint32_t JSToUint(JSContext* ctx, JSValue obj, const char* property)
+    {
+        JSValue val = JS_GetPropertyStr(ctx, obj, property);
+        uint32_t output = JSToUint(ctx, val);
+        JS_FreeValue(ctx, val);
+        return output;
+    }
+
+    inline CoordsXYZ JSToCoordXYZ(JSContext* ctx, JSValue obj)
+    {
+        return {
+            JSToInt(ctx, obj, "x"),
+            JSToInt(ctx, obj, "y"),
+            JSToInt(ctx, obj, "z")
+        };
+    }
+
     inline JSValue ToJSValue(JSContext* ctx, uint8_t val)
     {
         return JS_NewInt32(ctx, val);

--- a/src/openrct2/scripting/ScriptUtil.hpp
+++ b/src/openrct2/scripting/ScriptUtil.hpp
@@ -296,6 +296,14 @@ namespace OpenRCT2::Scripting
         return output;
     }
 
+    inline CoordsXY JSToCoordXY(JSContext* ctx, JSValue obj)
+    {
+        return {
+            JSToInt(ctx, obj, "x"),
+            JSToInt(ctx, obj, "y")
+        };
+    }
+
     inline CoordsXYZ JSToCoordXYZ(JSContext* ctx, JSValue obj)
     {
         return {
@@ -433,7 +441,7 @@ namespace OpenRCT2::Scripting
             return JS_EXCEPTION;                                                                                               \
         }                                                                                                                      \
         {                                                                                                                      \
-            const int result = JS_ToBool(ctx, value);                                                                          \
+            const int result = JS_ToBool(ctx, val);                                                                          \
             if (result == -1)                                                                                                  \
             {                                                                                                                  \
                 return JS_EXCEPTION;                                                                                           \

--- a/src/openrct2/scripting/ScriptUtil.hpp
+++ b/src/openrct2/scripting/ScriptUtil.hpp
@@ -303,6 +303,14 @@ namespace OpenRCT2::Scripting
             JSToInt(ctx, obj, "y")
         };
     }
+    
+    inline CoordsXY JSToCoordXY(JSContext* ctx, JSValue obj, const char* property)
+    {
+        JSValue val = JS_GetPropertyStr(ctx, obj, property);
+        CoordsXY output = JSToCoordXY(ctx, val);
+        JS_FreeValue(ctx, val);
+        return output;
+    }
 
     inline CoordsXYZ JSToCoordXYZ(JSContext* ctx, JSValue obj)
     {

--- a/src/openrct2/scripting/ScriptUtil.hpp
+++ b/src/openrct2/scripting/ScriptUtil.hpp
@@ -217,6 +217,22 @@ namespace OpenRCT2::Scripting
         return output;
     }
 
+    inline uint32_t AsOrDefault(JSContext* ctx, JSValue obj, const char* property, uint32_t def)
+    {
+        JSValue val = JS_GetPropertyStr(ctx, obj, property);
+        uint32_t output;
+        if (!JS_IsNumber(val))
+        {
+            output = def;
+        }
+        else if (JS_ToUint32(ctx, &output, val) < 0)
+        {
+            output = def;
+        }
+        JS_FreeValue(ctx, val);
+        return output;
+    }
+
     // Note the default parameter needs to be const char*
     // If you use a type like string_view, calls can instead resolve to the boolean version of the function.
     inline std::string AsOrDefault(JSContext* ctx, JSValue obj, const char* property, const char* def)

--- a/src/openrct2/scripting/ScriptUtil.hpp
+++ b/src/openrct2/scripting/ScriptUtil.hpp
@@ -453,6 +453,19 @@ namespace OpenRCT2::Scripting
             return JS_EXCEPTION;                                                                                               \
         }
 
+
+    #define JS_UNPACK_MONEY64(var, ctx, val)                                                                                   \
+        money64 var;                                                                                                           \
+        if (!JS_IsNumber(val))                                                                                                 \
+        {                                                                                                                      \
+            JS_ThrowTypeError(ctx, "Expected number");                                                                         \
+            return JS_EXCEPTION;                                                                                               \
+        }                                                                                                                      \
+        if (JS_ToInt64(ctx, &var, val) < 0)                                                                                    \
+        {                                                                                                                      \
+            return JS_EXCEPTION;                                                                                               \
+        }
+
     #define JS_UNPACK_STR(var, ctx, val)                                                                                       \
         std::string var;                                                                                                       \
         if (!JS_IsString(val))                                                                                                 \
@@ -481,7 +494,7 @@ namespace OpenRCT2::Scripting
             return JS_EXCEPTION;                                                                                               \
         }                                                                                                                      \
         {                                                                                                                      \
-            const int result = JS_ToBool(ctx, val);                                                                          \
+            const int result = JS_ToBool(ctx, val);                                                                            \
             if (result == -1)                                                                                                  \
             {                                                                                                                  \
                 return JS_EXCEPTION;                                                                                           \

--- a/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
@@ -15,9 +15,6 @@
 
 namespace OpenRCT2::Scripting
 {
-    class ScEntity;
-    extern ScEntity gScEntity;
-
     void ScBalloon::AddFuncs(JSContext* ctx, JSValue obj)
     {
         static constexpr JSCFunctionListEntry funcs[] = {

--- a/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "ScBalloon.hpp"
 
@@ -15,40 +15,40 @@
 
 namespace OpenRCT2::Scripting
 {
-    ScBalloon::ScBalloon(EntityId Id)
-        : ScEntity(Id)
+    class ScEntity;
+    extern ScEntity gScEntity;
+
+    void ScBalloon::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("colour", &ScBalloon::colour_get, &ScBalloon::colour_set)
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScBalloon::Register(duk_context* ctx)
+    Balloon* ScBalloon::GetBalloon(JSValue thisVal)
     {
-        dukglue_set_base_class<ScEntity, ScBalloon>(ctx);
-        dukglue_register_property(ctx, &ScBalloon::colour_get, &ScBalloon::colour_set, "colour");
+        auto id = GetEntityId(thisVal);
+        return OpenRCT2::GetEntity<Balloon>(id);
     }
 
-    Balloon* ScBalloon::GetBalloon() const
+    JSValue ScBalloon::colour_get(JSContext* ctx, JSValue thisVal)
     {
-        return OpenRCT2::GetEntity<Balloon>(_id);
+        auto balloon = GetBalloon(thisVal);
+        return JS_NewUint32(ctx, balloon == nullptr ? 0 : balloon->colour);
     }
 
-    uint8_t ScBalloon::colour_get() const
+    JSValue ScBalloon::colour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        auto balloon = GetBalloon();
-        if (balloon != nullptr)
-        {
-            return balloon->colour;
-        }
-        return 0;
-    }
-
-    void ScBalloon::colour_set(uint8_t value)
-    {
-        auto balloon = GetBalloon();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto balloon = GetBalloon(thisVal);
         if (balloon != nullptr)
         {
             balloon->colour = value;
             balloon->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/entity/ScBalloon.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScBalloon.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "ScEntity.hpp"
 
@@ -17,19 +17,16 @@ struct Balloon;
 
 namespace OpenRCT2::Scripting
 {
-
-    class ScBalloon : public ScEntity
+    class ScBalloon final : public ScEntity
     {
     public:
-        ScBalloon(EntityId Id);
-
-        static void Register(duk_context* ctx);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
     private:
-        Balloon* GetBalloon() const;
+        static Balloon* GetBalloon(JSValue thisVal);
 
-        uint8_t colour_get() const;
-        void colour_set(uint8_t);
+        static JSValue colour_get(JSContext* ctx, JSValue thisVal);
+        static JSValue colour_set(JSContext* ctx, JSValue thisVal, JSValue value);
     };
 } // namespace OpenRCT2::Scripting
 #endif

--- a/src/openrct2/scripting/bindings/entity/ScEntity.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.cpp
@@ -1,0 +1,287 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2025 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING_REFACTOR
+
+    #include "ScEntity.hpp"
+
+    #include "../../../entity/Staff.h"
+    #include "ScBalloon.hpp"
+    #include "ScGuest.hpp"
+    #include "ScLitter.hpp"
+    #include "ScMoneyEffect.hpp"
+    #include "ScParticle.hpp"
+    #include "ScPeep.hpp"
+    #include "ScStaff.hpp"
+    #include "ScVehicle.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    static inline std::string EntityTypeToString(const EntityBase* entity)
+    {
+        const auto targetApiVersion = GetTargetAPIVersion();
+
+        if (entity != nullptr)
+        {
+            switch (entity->Type)
+            {
+                case EntityType::Vehicle:
+                    return "car";
+                case EntityType::Guest:
+                    if (targetApiVersion <= kApiVersionPeepDeprecation)
+                        return "peep";
+                    return "guest";
+                case EntityType::Staff:
+                    if (targetApiVersion <= kApiVersionPeepDeprecation)
+                        return "peep";
+                    return "staff";
+                case EntityType::SteamParticle:
+                    return "steam_particle";
+                case EntityType::MoneyEffect:
+                    return "money_effect";
+                case EntityType::CrashedVehicleParticle:
+                    return "crashed_vehicle_particle";
+                case EntityType::ExplosionCloud:
+                    return "explosion_cloud";
+                case EntityType::CrashSplash:
+                    return "crash_splash";
+                case EntityType::ExplosionFlare:
+                    return "explosion_flare";
+                case EntityType::Balloon:
+                    return "balloon";
+                case EntityType::Duck:
+                    return "duck";
+                case EntityType::JumpingFountain:
+                    return "jumping_fountain";
+                case EntityType::Litter:
+                    return "litter";
+                case EntityType::Null:
+                    return "unknown";
+                default:
+                    break;
+            }
+        }
+        return "unknown";
+    }
+
+    using OpaqueEntityData = struct
+    {
+        EntityId id;
+    };
+
+    JSValue ScEntity::id_get(JSContext* ctx, JSValue thisVal)
+    {
+        auto entity = GetEntity(thisVal);
+        if (entity == nullptr)
+            return JS_UNDEFINED;
+
+        return JS_NewInt32(ctx, entity->Id.ToUnderlying());
+    }
+
+    JSValue ScEntity::type_get(JSContext* ctx, JSValue thisVal)
+    {
+        auto entity = GetEntity(thisVal);
+        auto type = EntityTypeToString(entity);
+        return JSFromStdString(ctx, type);
+    }
+
+    // x getter and setter
+    JSValue ScEntity::x_get(JSContext* ctx, JSValue thisVal)
+    {
+        auto entity = GetEntity(thisVal);
+        return JS_NewInt32(ctx, entity != nullptr ? entity->x : 0);
+    }
+    JSValue ScEntity::x_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
+    {
+        JS_UNPACK_INT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetEntity(thisVal);
+        if (entity != nullptr)
+        {
+            entity->MoveTo({ value, entity->y, entity->z });
+        }
+        return JS_UNDEFINED;
+    }
+
+    // y getter and setter
+    JSValue ScEntity::y_get(JSContext* ctx, JSValue thisVal)
+    {
+        auto entity = GetEntity(thisVal);
+        return JS_NewInt32(ctx, entity != nullptr ? entity->y : 0);
+    }
+    JSValue ScEntity::y_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
+    {
+        JS_UNPACK_INT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetEntity(thisVal);
+        if (entity != nullptr)
+        {
+            entity->MoveTo({ entity->x, value, entity->z });
+        }
+        return JS_UNDEFINED;
+    }
+
+    // z getter and setter
+    JSValue ScEntity::z_get(JSContext* ctx, JSValue thisVal)
+    {
+        auto entity = GetEntity(thisVal);
+        return JS_NewInt32(ctx, entity != nullptr ? entity->z : 0);
+    }
+    JSValue ScEntity::z_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
+    {
+        JS_UNPACK_INT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetEntity(thisVal);
+        if (entity != nullptr)
+        {
+            entity->MoveTo({ entity->x, entity->y, value });
+        }
+        return JS_UNDEFINED;
+    }
+
+    JSValue ScEntity::remove(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
+    {
+        auto entity = GetEntity(thisVal);
+        if (entity != nullptr)
+        {
+            entity->Invalidate();
+            switch (entity->Type)
+            {
+                case EntityType::Vehicle:
+                    JS_ThrowPlainError(ctx, "Removing a vehicle is currently unsupported.");
+                    return JS_EXCEPTION;
+                case EntityType::Guest:
+                case EntityType::Staff:
+                {
+                    auto peep = entity->As<Peep>();
+                    // We can't remove a single peep from a ride at the moment as this can cause complications with the
+                    // vehicle car having an unsupported peep capacity.
+                    if (peep == nullptr || peep->State == PeepState::OnRide || peep->State == PeepState::EnteringRide)
+                    {
+                        JS_ThrowPlainError(ctx, "Removing a peep that is on a ride is currently unsupported.");
+                        return JS_EXCEPTION;
+                    }
+                    peep->Remove();
+                    break;
+                }
+                case EntityType::SteamParticle:
+                case EntityType::MoneyEffect:
+                case EntityType::CrashedVehicleParticle:
+                case EntityType::ExplosionCloud:
+                case EntityType::CrashSplash:
+                case EntityType::ExplosionFlare:
+                case EntityType::JumpingFountain:
+                case EntityType::Balloon:
+                case EntityType::Duck:
+                case EntityType::Litter:
+                    EntityRemove(entity);
+                    break;
+                case EntityType::Null:
+                    break;
+                default:
+                    break;
+            }
+        }
+        return JS_UNDEFINED;
+    }
+
+    EntityId ScEntity::GetEntityId(JSValue thisVal)
+    {
+        return gScEntity.GetOpaque<OpaqueEntityData*>(thisVal)->id;
+    }
+
+    EntityBase* ScEntity::GetEntity(JSValue thisVal)
+    {
+        auto id = GetEntityId(thisVal);
+        return OpenRCT2::GetEntity(id);
+    }
+
+    JSValue ScEntity::New(JSContext* ctx, EntityBase* entity)
+    {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("id", &ScEntity::id_get, nullptr),        JS_CGETSET_DEF("type", &ScEntity::type_get, nullptr),
+            JS_CGETSET_DEF("x", &ScEntity::x_get, &ScEntity::x_set), JS_CGETSET_DEF("y", &ScEntity::y_get, &ScEntity::y_set),
+            JS_CGETSET_DEF("z", &ScEntity::z_get, &ScEntity::z_set), JS_CFUNC_DEF("remove", 0, &ScEntity::remove)
+        };
+        auto entityId = entity->Id;
+        auto obj = MakeWithOpaque(ctx, funcs, new OpaqueEntityData{ entityId });
+        switch (entity->Type)
+        {
+            case EntityType::Balloon:
+            {
+                ScBalloon::AddFuncs(ctx, obj);
+                break;
+            }
+            case EntityType::CrashedVehicleParticle:
+            {
+                ScCrashedVehicleParticle::AddFuncs(ctx, obj);
+                break;
+            }
+            case EntityType::Guest:
+            {
+                ScPeep::AddFuncs(ctx, obj);
+                ScGuest::AddFuncs(ctx, obj);
+                break;
+            }
+            case EntityType::Litter:
+            {
+                ScLitter::AddFuncs(ctx, obj);
+                break;
+            }
+            case EntityType::MoneyEffect:
+            {
+                ScMoneyEffect::AddFuncs(ctx, obj);
+                break;
+            }
+            case EntityType::Staff:
+            {
+                ScPeep::AddFuncs(ctx, obj);
+                ScStaff::AddFuncs(ctx, obj);
+
+                auto staff = OpenRCT2::GetEntity<Staff>(entityId);
+                if (staff != nullptr)
+                {
+                    switch (staff->AssignedStaffType)
+                    {
+                        case StaffType::Handyman:
+                            ScHandyman::AddFuncs(ctx, obj);
+                            break;
+                        case StaffType::Mechanic:
+                            ScMechanic::AddFuncs(ctx, obj);
+                            break;
+                        case StaffType::Security:
+                            ScSecurity::AddFuncs(ctx, obj);
+                            break;
+                    }
+                }
+                break;
+            }
+            case EntityType::Vehicle:
+            {
+                ScVehicle::AddFuncs(ctx, obj);
+                break;
+            }
+        }
+        return obj;
+    }
+
+    void ScEntity::Register(JSContext* ctx)
+    {
+        RegisterBaseStr(ctx, "Entity", Finalize);
+    }
+
+    void ScEntity::Finalize(JSRuntime* rt, JSValue thisVal)
+    {
+        OpaqueEntityData* data = gScEntity.GetOpaque<OpaqueEntityData*>(thisVal);
+        if (data)
+            delete data;
+    }
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -198,14 +198,20 @@ namespace OpenRCT2::Scripting
             return JS_UNDEFINED;
         }
 
+    protected:
+        static EntityId GetEntityId(JSValue thisVal)
+        {
+            return gScEntity.GetOpaque<OpaqueEntityData*>(thisVal)->id;
+        }
+
         static EntityBase* GetEntity(JSValue thisVal) 
         {
-            OpaqueEntityData* data = gScEntity.GetOpaque<OpaqueEntityData*>(thisVal);
-            return OpenRCT2::GetEntity(data->id);
+            auto id = GetEntityId(thisVal);
+            return OpenRCT2::GetEntity(id);
         }
 
     public:
-        JSValue New(JSContext* ctx)
+        JSValue New(JSContext* ctx, EntityBase* entity)
         {
             static constexpr JSCFunctionListEntry funcs[] = {
                 JS_CGETSET_DEF("id", &ScEntity::id_get, nullptr),
@@ -215,7 +221,15 @@ namespace OpenRCT2::Scripting
                 JS_CGETSET_DEF("z", &ScEntity::z_get, &ScEntity::z_set),
                 JS_CFUNC_DEF("remove", 0, &ScEntity::remove)
             };
-            return MakeWithOpaque(ctx, funcs, nullptr);
+            auto obj = MakeWithOpaque(ctx, funcs, new OpaqueEntityData{ entity->Id });
+            switch (entity->Type)
+            {
+                case EntityType::Balloon:
+                    // TODO: add extra funcs but they're in another file? Is this a circular reference?
+                    //ScBalloon::AddFuncs(ctx, obj);
+                    break;
+            }
+            return obj;
         }
 
         void Register(JSContext* ctx)

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -160,7 +160,7 @@ namespace OpenRCT2::Scripting
                 {
                     case EntityType::Vehicle:
                         JS_ThrowPlainError(ctx, "Removing a vehicle is currently unsupported.");
-                        break;
+                        return JS_EXCEPTION;
                     case EntityType::Guest:
                     case EntityType::Staff:
                     {
@@ -170,11 +170,9 @@ namespace OpenRCT2::Scripting
                         if (peep == nullptr || peep->State == PeepState::OnRide || peep->State == PeepState::EnteringRide)
                         {
                             JS_ThrowPlainError(ctx, "Removing a peep that is on a ride is currently unsupported.");
+                            return JS_EXCEPTION;
                         }
-                        else
-                        {
-                            peep->Remove();
-                        }
+                        peep->Remove();
                         break;
                     }
                     case EntityType::SteamParticle:

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -93,7 +93,7 @@ namespace OpenRCT2::Scripting
         {
             auto entity = GetEntity(thisVal);
             auto type = EntityTypeToString(entity);
-            return JS_NewString(ctx, type.c_str());
+            return JSFromStdString(ctx, type);
         }
 
         // x getter and setter

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -9,13 +9,12 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "../../../Context.h"
     #include "../../../entity/EntityList.h"
     #include "../../../entity/EntityRegistry.h"
     #include "../../../entity/Peep.h"
-    #include "../../Duktape.hpp"
     #include "../../ScriptEngine.h"
 
     #include <string_view>
@@ -23,136 +22,144 @@
 
 namespace OpenRCT2::Scripting
 {
-    class ScEntity
+    inline std::string EntityTypeToString(const EntityBase* entity)
     {
-    protected:
-        EntityId _id{ EntityId::GetNull() };
+        const auto targetApiVersion = GetTargetAPIVersion();
 
-    public:
-        ScEntity(EntityId id)
-            : _id(id)
+        if (entity != nullptr)
         {
-        }
-
-    private:
-        DukValue id_get() const
-        {
-            auto ctx = GetContext()->GetScriptEngine().GetContext();
-
-            auto entity = GetEntity();
-            if (entity == nullptr)
-                return ToDuk(ctx, nullptr);
-
-            return ToDuk(ctx, entity->Id.ToUnderlying());
-        }
-
-        std::string type_get() const
-        {
-            const auto targetApiVersion = GetTargetAPIVersion();
-
-            auto entity = GetEntity();
-            if (entity != nullptr)
+            switch (entity->Type)
             {
-                switch (entity->Type)
-                {
-                    case EntityType::Vehicle:
-                        return "car";
-                    case EntityType::Guest:
-                        if (targetApiVersion <= kApiVersionPeepDeprecation)
-                            return "peep";
-                        return "guest";
-                    case EntityType::Staff:
-                        if (targetApiVersion <= kApiVersionPeepDeprecation)
-                            return "peep";
-                        return "staff";
-                    case EntityType::SteamParticle:
-                        return "steam_particle";
-                    case EntityType::MoneyEffect:
-                        return "money_effect";
-                    case EntityType::CrashedVehicleParticle:
-                        return "crashed_vehicle_particle";
-                    case EntityType::ExplosionCloud:
-                        return "explosion_cloud";
-                    case EntityType::CrashSplash:
-                        return "crash_splash";
-                    case EntityType::ExplosionFlare:
-                        return "explosion_flare";
-                    case EntityType::Balloon:
-                        return "balloon";
-                    case EntityType::Duck:
-                        return "duck";
-                    case EntityType::JumpingFountain:
-                        return "jumping_fountain";
-                    case EntityType::Litter:
-                        return "litter";
-                    case EntityType::Null:
-                        return "unknown";
-                    default:
-                        break;
-                }
+                case EntityType::Vehicle:
+                    return "car";
+                case EntityType::Guest:
+                    if (targetApiVersion <= kApiVersionPeepDeprecation)
+                        return "peep";
+                    return "guest";
+                case EntityType::Staff:
+                    if (targetApiVersion <= kApiVersionPeepDeprecation)
+                        return "peep";
+                    return "staff";
+                case EntityType::SteamParticle:
+                    return "steam_particle";
+                case EntityType::MoneyEffect:
+                    return "money_effect";
+                case EntityType::CrashedVehicleParticle:
+                    return "crashed_vehicle_particle";
+                case EntityType::ExplosionCloud:
+                    return "explosion_cloud";
+                case EntityType::CrashSplash:
+                    return "crash_splash";
+                case EntityType::ExplosionFlare:
+                    return "explosion_flare";
+                case EntityType::Balloon:
+                    return "balloon";
+                case EntityType::Duck:
+                    return "duck";
+                case EntityType::JumpingFountain:
+                    return "jumping_fountain";
+                case EntityType::Litter:
+                    return "litter";
+                case EntityType::Null:
+                    return "unknown";
+                default:
+                    break;
             }
-            return "unknown";
+        }
+        return "unknown";
+    }
+
+    class ScEntity;
+    extern ScEntity gScEntity;
+
+    using OpaqueEntityData = struct
+    {
+        EntityId id;
+    };
+
+    class ScEntity : public ScBase
+    {
+    private:
+        static JSValue id_get(JSContext* ctx, JSValue thisVal)
+        {
+            auto entity = GetEntity(thisVal);
+            if (entity == nullptr)
+                return JS_UNDEFINED;
+
+            return JS_NewInt32(ctx, entity->Id.ToUnderlying());
+        }
+
+        static JSValue type_get(JSContext* ctx, JSValue thisVal)
+        {
+            auto entity = GetEntity(thisVal);
+            auto type = EntityTypeToString(entity);
+            return JS_NewString(ctx, type.c_str());
         }
 
         // x getter and setter
-        int32_t x_get() const
+        static JSValue x_get(JSContext* ctx, JSValue thisVal)
         {
-            auto entity = GetEntity();
-            return entity != nullptr ? entity->x : 0;
+            auto entity = GetEntity(thisVal);
+            return JS_NewInt32(ctx, entity != nullptr ? entity->x : 0);
         }
-        void x_set(int32_t value)
+        static JSValue x_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
         {
-            ThrowIfGameStateNotMutable();
-            auto entity = GetEntity();
+            JS_UNPACK_INT32(value, ctx, jsValue);
+            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+            auto entity = GetEntity(thisVal);
             if (entity != nullptr)
             {
                 entity->MoveTo({ value, entity->y, entity->z });
             }
+            return JS_UNDEFINED;
         }
 
         // y getter and setter
-        int32_t y_get() const
+        static JSValue y_get(JSContext* ctx, JSValue thisVal)
         {
-            auto entity = GetEntity();
-            return entity != nullptr ? entity->y : 0;
+            auto entity = GetEntity(thisVal);
+            return JS_NewInt32(ctx, entity != nullptr ? entity->y : 0);
         }
-        void y_set(int32_t value)
+        static JSValue y_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
         {
-            ThrowIfGameStateNotMutable();
-            auto entity = GetEntity();
+            JS_UNPACK_INT32(value, ctx, jsValue);
+            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+            auto entity = GetEntity(thisVal);
             if (entity != nullptr)
             {
                 entity->MoveTo({ entity->x, value, entity->z });
             }
+            return JS_UNDEFINED;
         }
 
         // z getter and setter
-        int16_t z_get() const
+        static JSValue z_get(JSContext* ctx, JSValue thisVal)
         {
-            auto entity = GetEntity();
-            return entity != nullptr ? entity->z : 0;
+            auto entity = GetEntity(thisVal);
+            return JS_NewInt32(ctx, entity != nullptr ? entity->z : 0);
         }
-        void z_set(int16_t value)
+        static JSValue z_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
         {
-            ThrowIfGameStateNotMutable();
-            auto entity = GetEntity();
+            JS_UNPACK_INT32(value, ctx, jsValue);
+            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+            auto entity = GetEntity(thisVal);
             if (entity != nullptr)
             {
                 entity->MoveTo({ entity->x, entity->y, value });
             }
+            return JS_UNDEFINED;
         }
 
-        void remove()
+        static JSValue remove(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
         {
-            auto ctx = GetContext()->GetScriptEngine().GetContext();
-            auto entity = GetEntity();
+            auto entity = GetEntity(thisVal);
             if (entity != nullptr)
             {
                 entity->Invalidate();
                 switch (entity->Type)
                 {
                     case EntityType::Vehicle:
-                        duk_error(ctx, DUK_ERR_ERROR, "Removing a vehicle is currently unsupported.");
+                        JS_ThrowPlainError(ctx, "Removing a vehicle is currently unsupported.");
                         break;
                     case EntityType::Guest:
                     case EntityType::Staff:
@@ -162,7 +169,7 @@ namespace OpenRCT2::Scripting
                         // vehicle car having an unsupported peep capacity.
                         if (peep == nullptr || peep->State == PeepState::OnRide || peep->State == PeepState::EnteringRide)
                         {
-                            duk_error(ctx, DUK_ERR_ERROR, "Removing a peep that is on a ride is currently unsupported.");
+                            JS_ThrowPlainError(ctx, "Removing a peep that is on a ride is currently unsupported.");
                         }
                         else
                         {
@@ -188,22 +195,32 @@ namespace OpenRCT2::Scripting
                         break;
                 }
             }
+            return JS_UNDEFINED;
         }
 
-        EntityBase* GetEntity() const
+        static EntityBase* GetEntity(JSValue thisVal) 
         {
-            return OpenRCT2::GetEntity(_id);
+            OpaqueEntityData* data = gScEntity.GetOpaque<OpaqueEntityData*>(thisVal);
+            return OpenRCT2::GetEntity(data->id);
         }
 
     public:
-        static void Register(duk_context* ctx)
+        JSValue New(JSContext* ctx)
         {
-            dukglue_register_property(ctx, &ScEntity::id_get, nullptr, "id");
-            dukglue_register_property(ctx, &ScEntity::type_get, nullptr, "type");
-            dukglue_register_property(ctx, &ScEntity::x_get, &ScEntity::x_set, "x");
-            dukglue_register_property(ctx, &ScEntity::y_get, &ScEntity::y_set, "y");
-            dukglue_register_property(ctx, &ScEntity::z_get, &ScEntity::z_set, "z");
-            dukglue_register_method(ctx, &ScEntity::remove, "remove");
+            static constexpr JSCFunctionListEntry funcs[] = {
+                JS_CGETSET_DEF("id", &ScEntity::id_get, nullptr),
+                JS_CGETSET_DEF("type", &ScEntity::type_get, nullptr),
+                JS_CGETSET_DEF("x", &ScEntity::x_get, &ScEntity::x_set),
+                JS_CGETSET_DEF("y", &ScEntity::y_get, &ScEntity::y_set),
+                JS_CGETSET_DEF("z", &ScEntity::z_get, &ScEntity::z_set),
+                JS_CFUNC_DEF("remove", 0, &ScEntity::remove)
+            };
+            return MakeWithOpaque(ctx, funcs, nullptr);
+        }
+
+        void Register(JSContext* ctx)
+        {
+            RegisterBaseStr(ctx, "Cheats");
         }
     };
 

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -220,7 +220,15 @@ namespace OpenRCT2::Scripting
 
         void Register(JSContext* ctx)
         {
-            RegisterBaseStr(ctx, "Cheats");
+            RegisterBaseStr(ctx, "Entity", Finalize);
+        }
+
+    private: 
+        static void Finalize(JSRuntime* rt, JSValue thisVal)
+        {
+            OpaqueEntityData* data = gScEntity.GetOpaque<OpaqueEntityData*>(thisVal);
+            if (data)
+                delete data;
         }
     };
 

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -22,226 +22,40 @@
 
 namespace OpenRCT2::Scripting
 {
-    inline std::string EntityTypeToString(const EntityBase* entity)
-    {
-        const auto targetApiVersion = GetTargetAPIVersion();
-
-        if (entity != nullptr)
-        {
-            switch (entity->Type)
-            {
-                case EntityType::Vehicle:
-                    return "car";
-                case EntityType::Guest:
-                    if (targetApiVersion <= kApiVersionPeepDeprecation)
-                        return "peep";
-                    return "guest";
-                case EntityType::Staff:
-                    if (targetApiVersion <= kApiVersionPeepDeprecation)
-                        return "peep";
-                    return "staff";
-                case EntityType::SteamParticle:
-                    return "steam_particle";
-                case EntityType::MoneyEffect:
-                    return "money_effect";
-                case EntityType::CrashedVehicleParticle:
-                    return "crashed_vehicle_particle";
-                case EntityType::ExplosionCloud:
-                    return "explosion_cloud";
-                case EntityType::CrashSplash:
-                    return "crash_splash";
-                case EntityType::ExplosionFlare:
-                    return "explosion_flare";
-                case EntityType::Balloon:
-                    return "balloon";
-                case EntityType::Duck:
-                    return "duck";
-                case EntityType::JumpingFountain:
-                    return "jumping_fountain";
-                case EntityType::Litter:
-                    return "litter";
-                case EntityType::Null:
-                    return "unknown";
-                default:
-                    break;
-            }
-        }
-        return "unknown";
-    }
-
     class ScEntity;
     extern ScEntity gScEntity;
-
-    using OpaqueEntityData = struct
-    {
-        EntityId id;
-    };
 
     class ScEntity : public ScBase
     {
     private:
-        static JSValue id_get(JSContext* ctx, JSValue thisVal)
-        {
-            auto entity = GetEntity(thisVal);
-            if (entity == nullptr)
-                return JS_UNDEFINED;
-
-            return JS_NewInt32(ctx, entity->Id.ToUnderlying());
-        }
-
-        static JSValue type_get(JSContext* ctx, JSValue thisVal)
-        {
-            auto entity = GetEntity(thisVal);
-            auto type = EntityTypeToString(entity);
-            return JSFromStdString(ctx, type);
-        }
+        static JSValue id_get(JSContext* ctx, JSValue thisVal);
+        static JSValue type_get(JSContext* ctx, JSValue thisVal);
 
         // x getter and setter
-        static JSValue x_get(JSContext* ctx, JSValue thisVal)
-        {
-            auto entity = GetEntity(thisVal);
-            return JS_NewInt32(ctx, entity != nullptr ? entity->x : 0);
-        }
-        static JSValue x_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
-        {
-            JS_UNPACK_INT32(value, ctx, jsValue);
-            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
-            auto entity = GetEntity(thisVal);
-            if (entity != nullptr)
-            {
-                entity->MoveTo({ value, entity->y, entity->z });
-            }
-            return JS_UNDEFINED;
-        }
+        static JSValue x_get(JSContext* ctx, JSValue thisVal);
+        static JSValue x_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
         // y getter and setter
-        static JSValue y_get(JSContext* ctx, JSValue thisVal)
-        {
-            auto entity = GetEntity(thisVal);
-            return JS_NewInt32(ctx, entity != nullptr ? entity->y : 0);
-        }
-        static JSValue y_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
-        {
-            JS_UNPACK_INT32(value, ctx, jsValue);
-            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
-            auto entity = GetEntity(thisVal);
-            if (entity != nullptr)
-            {
-                entity->MoveTo({ entity->x, value, entity->z });
-            }
-            return JS_UNDEFINED;
-        }
+        static JSValue y_get(JSContext* ctx, JSValue thisVal);
+        static JSValue y_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
         // z getter and setter
-        static JSValue z_get(JSContext* ctx, JSValue thisVal)
-        {
-            auto entity = GetEntity(thisVal);
-            return JS_NewInt32(ctx, entity != nullptr ? entity->z : 0);
-        }
-        static JSValue z_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
-        {
-            JS_UNPACK_INT32(value, ctx, jsValue);
-            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
-            auto entity = GetEntity(thisVal);
-            if (entity != nullptr)
-            {
-                entity->MoveTo({ entity->x, entity->y, value });
-            }
-            return JS_UNDEFINED;
-        }
+        static JSValue z_get(JSContext* ctx, JSValue thisVal);
+        static JSValue z_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        static JSValue remove(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
-        {
-            auto entity = GetEntity(thisVal);
-            if (entity != nullptr)
-            {
-                entity->Invalidate();
-                switch (entity->Type)
-                {
-                    case EntityType::Vehicle:
-                        JS_ThrowPlainError(ctx, "Removing a vehicle is currently unsupported.");
-                        return JS_EXCEPTION;
-                    case EntityType::Guest:
-                    case EntityType::Staff:
-                    {
-                        auto peep = entity->As<Peep>();
-                        // We can't remove a single peep from a ride at the moment as this can cause complications with the
-                        // vehicle car having an unsupported peep capacity.
-                        if (peep == nullptr || peep->State == PeepState::OnRide || peep->State == PeepState::EnteringRide)
-                        {
-                            JS_ThrowPlainError(ctx, "Removing a peep that is on a ride is currently unsupported.");
-                            return JS_EXCEPTION;
-                        }
-                        peep->Remove();
-                        break;
-                    }
-                    case EntityType::SteamParticle:
-                    case EntityType::MoneyEffect:
-                    case EntityType::CrashedVehicleParticle:
-                    case EntityType::ExplosionCloud:
-                    case EntityType::CrashSplash:
-                    case EntityType::ExplosionFlare:
-                    case EntityType::JumpingFountain:
-                    case EntityType::Balloon:
-                    case EntityType::Duck:
-                    case EntityType::Litter:
-                        EntityRemove(entity);
-                        break;
-                    case EntityType::Null:
-                        break;
-                    default:
-                        break;
-                }
-            }
-            return JS_UNDEFINED;
-        }
+        static JSValue remove(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
 
     protected:
-        static EntityId GetEntityId(JSValue thisVal)
-        {
-            return gScEntity.GetOpaque<OpaqueEntityData*>(thisVal)->id;
-        }
-
-        static EntityBase* GetEntity(JSValue thisVal) 
-        {
-            auto id = GetEntityId(thisVal);
-            return OpenRCT2::GetEntity(id);
-        }
+        static EntityId GetEntityId(JSValue thisVal);
+        static EntityBase* GetEntity(JSValue thisVal);
 
     public:
-        JSValue New(JSContext* ctx, EntityBase* entity)
-        {
-            static constexpr JSCFunctionListEntry funcs[] = {
-                JS_CGETSET_DEF("id", &ScEntity::id_get, nullptr),
-                JS_CGETSET_DEF("type", &ScEntity::type_get, nullptr),
-                JS_CGETSET_DEF("x", &ScEntity::x_get, &ScEntity::x_set),
-                JS_CGETSET_DEF("y", &ScEntity::y_get, &ScEntity::y_set),
-                JS_CGETSET_DEF("z", &ScEntity::z_get, &ScEntity::z_set),
-                JS_CFUNC_DEF("remove", 0, &ScEntity::remove)
-            };
-            auto obj = MakeWithOpaque(ctx, funcs, new OpaqueEntityData{ entity->Id });
-            switch (entity->Type)
-            {
-                case EntityType::Balloon:
-                    // TODO: add extra funcs but they're in another file? Is this a circular reference?
-                    //ScBalloon::AddFuncs(ctx, obj);
-                    break;
-            }
-            return obj;
-        }
+        JSValue New(JSContext* ctx, EntityBase* entity);
 
-        void Register(JSContext* ctx)
-        {
-            RegisterBaseStr(ctx, "Entity", Finalize);
-        }
+        void Register(JSContext* ctx);
 
     private: 
-        static void Finalize(JSRuntime* rt, JSValue thisVal)
-        {
-            OpaqueEntityData* data = gScEntity.GetOpaque<OpaqueEntityData*>(thisVal);
-            if (data)
-                delete data;
-        }
+        static void Finalize(JSRuntime* rt, JSValue thisVal);
     };
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -744,16 +744,16 @@ namespace OpenRCT2::Scripting
         return true;
     }
 
-    JSValue ScGuest::has_item(JSContext * ctx, JSValue thisVal, int argc, JSValue* argv)
+    JSValue ScGuest::has_item(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_OBJECT(item, ctx, argv[1]); // todo out of bounds?
+        JS_UNPACK_OBJECT(item, ctx, argv[0]);
         auto result = has_item(ctx, thisVal, item);
         return JS_NewBool(ctx, result);
     }
 
     JSValue ScGuest::give_item(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_OBJECT(item, ctx, argv[1]); // todo out of bounds?
+        JS_UNPACK_OBJECT(item, ctx, argv[0]);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto peep = GetGuest(thisVal);
@@ -864,7 +864,7 @@ namespace OpenRCT2::Scripting
 
     JSValue ScGuest::remove_item(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_OBJECT(item, ctx, argv[1]); // todo out of bounds?
+        JS_UNPACK_OBJECT(item, ctx, argv[0]);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
         if (has_item(ctx, thisVal, item))
         {
@@ -903,8 +903,8 @@ namespace OpenRCT2::Scripting
 
     JSValue ScGuest::getAnimationSpriteIds(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_STR(groupKey, ctx, argv[1]);
-        JS_UNPACK_UINT32(rotation, ctx, argv[2]);
+        JS_UNPACK_STR(groupKey, ctx, argv[0]);
+        JS_UNPACK_UINT32(rotation, ctx, argv[1]);
         JSValue spriteIds = JS_NewArray(ctx);
 
         auto& availableGuestAnimations = getAnimationsByPeepType(AnimationPeepType::Guest);
@@ -931,7 +931,6 @@ namespace OpenRCT2::Scripting
                     imageId += frameOffset;
 
                 JS_SetPropertyInt64(ctx, spriteIds, idx++, JS_NewUint32(ctx, imageId));
-
             }
         }
         return spriteIds;

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -1039,8 +1039,6 @@ namespace OpenRCT2::Scripting
         return JS_NewUint32(ctx, static_cast<uint32_t>(animationGroup.frame_offsets.size()));
     }
 
-    extern ScThought gScThought;
-
     using OpaqueThoughtData = struct
     {
         PeepThought thought;

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "ScGuest.hpp"
 
@@ -21,548 +21,568 @@
 
 namespace OpenRCT2::Scripting
 {
-    static const DukEnumMap<PeepThoughtType> ThoughtTypeMap(
-        {
-            { "cant_afford_ride", PeepThoughtType::CantAffordRide },
-            { "spent_money", PeepThoughtType::SpentMoney },
-            { "sick", PeepThoughtType::Sick },
-            { "very_sick", PeepThoughtType::VerySick },
-            { "more_thrilling", PeepThoughtType::MoreThrilling },
-            { "intense", PeepThoughtType::Intense },
-            { "havent_finished", PeepThoughtType::HaventFinished },
-            { "sickening", PeepThoughtType::Sickening },
-            { "bad_value", PeepThoughtType::BadValue },
-            { "go_home", PeepThoughtType::GoHome },
-            { "good_value", PeepThoughtType::GoodValue },
-            { "already_got", PeepThoughtType::AlreadyGot },
-            { "cant_afford_item", PeepThoughtType::CantAffordItem },
-            { "not_hungry", PeepThoughtType::NotHungry },
-            { "not_thirsty", PeepThoughtType::NotThirsty },
-            { "drowning", PeepThoughtType::Drowning },
-            { "lost", PeepThoughtType::Lost },
-            { "was_great", PeepThoughtType::WasGreat },
-            { "queuing_ages", PeepThoughtType::QueuingAges },
-            { "tired", PeepThoughtType::Tired },
-            { "hungry", PeepThoughtType::Hungry },
-            { "thirsty", PeepThoughtType::Thirsty },
-            { "toilet", PeepThoughtType::Toilet },
-            { "cant_find", PeepThoughtType::CantFind },
-            { "not_paying", PeepThoughtType::NotPaying },
-            { "not_while_raining", PeepThoughtType::NotWhileRaining },
-            { "bad_litter", PeepThoughtType::BadLitter },
-            { "cant_find_exit", PeepThoughtType::CantFindExit },
-            { "get_off", PeepThoughtType::GetOff },
-            { "get_out", PeepThoughtType::GetOut },
-            { "not_safe", PeepThoughtType::NotSafe },
-            { "path_disgusting", PeepThoughtType::PathDisgusting },
-            { "crowded", PeepThoughtType::Crowded },
-            { "vandalism", PeepThoughtType::Vandalism },
-            { "scenery", PeepThoughtType::Scenery },
-            { "very_clean", PeepThoughtType::VeryClean },
-            { "fountains", PeepThoughtType::Fountains },
-            { "music", PeepThoughtType::Music },
-            { "balloon", PeepThoughtType::Balloon },
-            { "toy", PeepThoughtType::Toy },
-            { "map", PeepThoughtType::Map },
-            { "photo", PeepThoughtType::Photo },
-            { "umbrella", PeepThoughtType::Umbrella },
-            { "drink", PeepThoughtType::Drink },
-            { "burger", PeepThoughtType::Burger },
-            { "chips", PeepThoughtType::Chips },
-            { "ice_cream", PeepThoughtType::IceCream },
-            { "candyfloss", PeepThoughtType::Candyfloss },
-            { "pizza", PeepThoughtType::Pizza },
-            { "popcorn", PeepThoughtType::Popcorn },
-            { "hot_dog", PeepThoughtType::HotDog },
-            { "tentacle", PeepThoughtType::Tentacle },
-            { "hat", PeepThoughtType::Hat },
-            { "toffee_apple", PeepThoughtType::ToffeeApple },
-            { "tshirt", PeepThoughtType::Tshirt },
-            { "doughnut", PeepThoughtType::Doughnut },
-            { "coffee", PeepThoughtType::Coffee },
-            { "chicken", PeepThoughtType::Chicken },
-            { "lemonade", PeepThoughtType::Lemonade },
-            { "wow", PeepThoughtType::Wow },
-            { "wow2", PeepThoughtType::Wow2 },
-            { "watched", PeepThoughtType::Watched },
-            { "balloon_much", PeepThoughtType::BalloonMuch },
-            { "toy_much", PeepThoughtType::ToyMuch },
-            { "map_much", PeepThoughtType::MapMuch },
-            { "photo_much", PeepThoughtType::PhotoMuch },
-            { "umbrella_much", PeepThoughtType::UmbrellaMuch },
-            { "drink_much", PeepThoughtType::DrinkMuch },
-            { "burger_much", PeepThoughtType::BurgerMuch },
-            { "chips_much", PeepThoughtType::ChipsMuch },
-            { "ice_cream_much", PeepThoughtType::IceCreamMuch },
-            { "candyfloss_much", PeepThoughtType::CandyflossMuch },
-            { "pizza_much", PeepThoughtType::PizzaMuch },
-            { "popcorn_much", PeepThoughtType::PopcornMuch },
-            { "hot_dog_much", PeepThoughtType::HotDogMuch },
-            { "tentacle_much", PeepThoughtType::TentacleMuch },
-            { "hat_much", PeepThoughtType::HatMuch },
-            { "toffee_apple_much", PeepThoughtType::ToffeeAppleMuch },
-            { "tshirt_much", PeepThoughtType::TshirtMuch },
-            { "doughnut_much", PeepThoughtType::DoughnutMuch },
-            { "coffee_much", PeepThoughtType::CoffeeMuch },
-            { "chicken_much", PeepThoughtType::ChickenMuch },
-            { "lemonade_much", PeepThoughtType::LemonadeMuch },
-            { "photo2", PeepThoughtType::Photo2 },
-            { "photo3", PeepThoughtType::Photo3 },
-            { "photo4", PeepThoughtType::Photo4 },
-            { "pretzel", PeepThoughtType::Pretzel },
-            { "hot_chocolate", PeepThoughtType::HotChocolate },
-            { "iced_tea", PeepThoughtType::IcedTea },
-            { "funnel_cake", PeepThoughtType::FunnelCake },
-            { "sunglasses", PeepThoughtType::Sunglasses },
-            { "beef_noodles", PeepThoughtType::BeefNoodles },
-            { "fried_rice_noodles", PeepThoughtType::FriedRiceNoodles },
-            { "wonton_soup", PeepThoughtType::WontonSoup },
-            { "meatball_soup", PeepThoughtType::MeatballSoup },
-            { "fruit_juice", PeepThoughtType::FruitJuice },
-            { "soybean_milk", PeepThoughtType::SoybeanMilk },
-            { "sujongkwa", PeepThoughtType::Sujongkwa },
-            { "sub_sandwich", PeepThoughtType::SubSandwich },
-            { "cookie", PeepThoughtType::Cookie },
-            { "roast_sausage", PeepThoughtType::RoastSausage },
-            { "photo2_much", PeepThoughtType::Photo2Much },
-            { "photo3_much", PeepThoughtType::Photo3Much },
-            { "photo4_much", PeepThoughtType::Photo4Much },
-            { "pretzel_much", PeepThoughtType::PretzelMuch },
-            { "hot_chocolate_much", PeepThoughtType::HotChocolateMuch },
-            { "iced_tea_much", PeepThoughtType::IcedTeaMuch },
-            { "funnel_cake_much", PeepThoughtType::FunnelCakeMuch },
-            { "sunglasses_much", PeepThoughtType::SunglassesMuch },
-            { "beef_noodles_much", PeepThoughtType::BeefNoodlesMuch },
-            { "fried_rice_noodles_much", PeepThoughtType::FriedRiceNoodlesMuch },
-            { "wonton_soup_much", PeepThoughtType::WontonSoupMuch },
-            { "meatball_soup_much", PeepThoughtType::MeatballSoupMuch },
-            { "fruit_juice_much", PeepThoughtType::FruitJuiceMuch },
-            { "soybean_milk_much", PeepThoughtType::SoybeanMilkMuch },
-            { "sujongkwa_much", PeepThoughtType::SujongkwaMuch },
-            { "sub_sandwich_much", PeepThoughtType::SubSandwichMuch },
-            { "cookie_much", PeepThoughtType::CookieMuch },
-            { "roast_sausage_much", PeepThoughtType::RoastSausageMuch },
-            { "help", PeepThoughtType::Help },
-            { "running_out", PeepThoughtType::RunningOut },
-            { "new_ride", PeepThoughtType::NewRide },
-            { "nice_ride_deprecated", PeepThoughtType::NiceRideDeprecated },
-            { "excited_deprecated", PeepThoughtType::ExcitedDeprecated },
-            { "here_we_are", PeepThoughtType::HereWeAre },
-        });
+    static const EnumMap<PeepThoughtType> ThoughtTypeMap({
+        { "cant_afford_ride", PeepThoughtType::CantAffordRide },
+        { "spent_money", PeepThoughtType::SpentMoney },
+        { "sick", PeepThoughtType::Sick },
+        { "very_sick", PeepThoughtType::VerySick },
+        { "more_thrilling", PeepThoughtType::MoreThrilling },
+        { "intense", PeepThoughtType::Intense },
+        { "havent_finished", PeepThoughtType::HaventFinished },
+        { "sickening", PeepThoughtType::Sickening },
+        { "bad_value", PeepThoughtType::BadValue },
+        { "go_home", PeepThoughtType::GoHome },
+        { "good_value", PeepThoughtType::GoodValue },
+        { "already_got", PeepThoughtType::AlreadyGot },
+        { "cant_afford_item", PeepThoughtType::CantAffordItem },
+        { "not_hungry", PeepThoughtType::NotHungry },
+        { "not_thirsty", PeepThoughtType::NotThirsty },
+        { "drowning", PeepThoughtType::Drowning },
+        { "lost", PeepThoughtType::Lost },
+        { "was_great", PeepThoughtType::WasGreat },
+        { "queuing_ages", PeepThoughtType::QueuingAges },
+        { "tired", PeepThoughtType::Tired },
+        { "hungry", PeepThoughtType::Hungry },
+        { "thirsty", PeepThoughtType::Thirsty },
+        { "toilet", PeepThoughtType::Toilet },
+        { "cant_find", PeepThoughtType::CantFind },
+        { "not_paying", PeepThoughtType::NotPaying },
+        { "not_while_raining", PeepThoughtType::NotWhileRaining },
+        { "bad_litter", PeepThoughtType::BadLitter },
+        { "cant_find_exit", PeepThoughtType::CantFindExit },
+        { "get_off", PeepThoughtType::GetOff },
+        { "get_out", PeepThoughtType::GetOut },
+        { "not_safe", PeepThoughtType::NotSafe },
+        { "path_disgusting", PeepThoughtType::PathDisgusting },
+        { "crowded", PeepThoughtType::Crowded },
+        { "vandalism", PeepThoughtType::Vandalism },
+        { "scenery", PeepThoughtType::Scenery },
+        { "very_clean", PeepThoughtType::VeryClean },
+        { "fountains", PeepThoughtType::Fountains },
+        { "music", PeepThoughtType::Music },
+        { "balloon", PeepThoughtType::Balloon },
+        { "toy", PeepThoughtType::Toy },
+        { "map", PeepThoughtType::Map },
+        { "photo", PeepThoughtType::Photo },
+        { "umbrella", PeepThoughtType::Umbrella },
+        { "drink", PeepThoughtType::Drink },
+        { "burger", PeepThoughtType::Burger },
+        { "chips", PeepThoughtType::Chips },
+        { "ice_cream", PeepThoughtType::IceCream },
+        { "candyfloss", PeepThoughtType::Candyfloss },
+        { "pizza", PeepThoughtType::Pizza },
+        { "popcorn", PeepThoughtType::Popcorn },
+        { "hot_dog", PeepThoughtType::HotDog },
+        { "tentacle", PeepThoughtType::Tentacle },
+        { "hat", PeepThoughtType::Hat },
+        { "toffee_apple", PeepThoughtType::ToffeeApple },
+        { "tshirt", PeepThoughtType::Tshirt },
+        { "doughnut", PeepThoughtType::Doughnut },
+        { "coffee", PeepThoughtType::Coffee },
+        { "chicken", PeepThoughtType::Chicken },
+        { "lemonade", PeepThoughtType::Lemonade },
+        { "wow", PeepThoughtType::Wow },
+        { "wow2", PeepThoughtType::Wow2 },
+        { "watched", PeepThoughtType::Watched },
+        { "balloon_much", PeepThoughtType::BalloonMuch },
+        { "toy_much", PeepThoughtType::ToyMuch },
+        { "map_much", PeepThoughtType::MapMuch },
+        { "photo_much", PeepThoughtType::PhotoMuch },
+        { "umbrella_much", PeepThoughtType::UmbrellaMuch },
+        { "drink_much", PeepThoughtType::DrinkMuch },
+        { "burger_much", PeepThoughtType::BurgerMuch },
+        { "chips_much", PeepThoughtType::ChipsMuch },
+        { "ice_cream_much", PeepThoughtType::IceCreamMuch },
+        { "candyfloss_much", PeepThoughtType::CandyflossMuch },
+        { "pizza_much", PeepThoughtType::PizzaMuch },
+        { "popcorn_much", PeepThoughtType::PopcornMuch },
+        { "hot_dog_much", PeepThoughtType::HotDogMuch },
+        { "tentacle_much", PeepThoughtType::TentacleMuch },
+        { "hat_much", PeepThoughtType::HatMuch },
+        { "toffee_apple_much", PeepThoughtType::ToffeeAppleMuch },
+        { "tshirt_much", PeepThoughtType::TshirtMuch },
+        { "doughnut_much", PeepThoughtType::DoughnutMuch },
+        { "coffee_much", PeepThoughtType::CoffeeMuch },
+        { "chicken_much", PeepThoughtType::ChickenMuch },
+        { "lemonade_much", PeepThoughtType::LemonadeMuch },
+        { "photo2", PeepThoughtType::Photo2 },
+        { "photo3", PeepThoughtType::Photo3 },
+        { "photo4", PeepThoughtType::Photo4 },
+        { "pretzel", PeepThoughtType::Pretzel },
+        { "hot_chocolate", PeepThoughtType::HotChocolate },
+        { "iced_tea", PeepThoughtType::IcedTea },
+        { "funnel_cake", PeepThoughtType::FunnelCake },
+        { "sunglasses", PeepThoughtType::Sunglasses },
+        { "beef_noodles", PeepThoughtType::BeefNoodles },
+        { "fried_rice_noodles", PeepThoughtType::FriedRiceNoodles },
+        { "wonton_soup", PeepThoughtType::WontonSoup },
+        { "meatball_soup", PeepThoughtType::MeatballSoup },
+        { "fruit_juice", PeepThoughtType::FruitJuice },
+        { "soybean_milk", PeepThoughtType::SoybeanMilk },
+        { "sujongkwa", PeepThoughtType::Sujongkwa },
+        { "sub_sandwich", PeepThoughtType::SubSandwich },
+        { "cookie", PeepThoughtType::Cookie },
+        { "roast_sausage", PeepThoughtType::RoastSausage },
+        { "photo2_much", PeepThoughtType::Photo2Much },
+        { "photo3_much", PeepThoughtType::Photo3Much },
+        { "photo4_much", PeepThoughtType::Photo4Much },
+        { "pretzel_much", PeepThoughtType::PretzelMuch },
+        { "hot_chocolate_much", PeepThoughtType::HotChocolateMuch },
+        { "iced_tea_much", PeepThoughtType::IcedTeaMuch },
+        { "funnel_cake_much", PeepThoughtType::FunnelCakeMuch },
+        { "sunglasses_much", PeepThoughtType::SunglassesMuch },
+        { "beef_noodles_much", PeepThoughtType::BeefNoodlesMuch },
+        { "fried_rice_noodles_much", PeepThoughtType::FriedRiceNoodlesMuch },
+        { "wonton_soup_much", PeepThoughtType::WontonSoupMuch },
+        { "meatball_soup_much", PeepThoughtType::MeatballSoupMuch },
+        { "fruit_juice_much", PeepThoughtType::FruitJuiceMuch },
+        { "soybean_milk_much", PeepThoughtType::SoybeanMilkMuch },
+        { "sujongkwa_much", PeepThoughtType::SujongkwaMuch },
+        { "sub_sandwich_much", PeepThoughtType::SubSandwichMuch },
+        { "cookie_much", PeepThoughtType::CookieMuch },
+        { "roast_sausage_much", PeepThoughtType::RoastSausageMuch },
+        { "help", PeepThoughtType::Help },
+        { "running_out", PeepThoughtType::RunningOut },
+        { "new_ride", PeepThoughtType::NewRide },
+        { "nice_ride_deprecated", PeepThoughtType::NiceRideDeprecated },
+        { "excited_deprecated", PeepThoughtType::ExcitedDeprecated },
+        { "here_we_are", PeepThoughtType::HereWeAre },
+    });
 
-    ScGuest::ScGuest(EntityId id)
-        : ScPeep(id)
+    void ScGuest::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("tshirtColour", &ScGuest::tshirtColour_get, &ScGuest::tshirtColour_set),
+            JS_CGETSET_DEF("trousersColour", &ScGuest::trousersColour_get, &ScGuest::trousersColour_set),
+            JS_CGETSET_DEF("balloonColour", &ScGuest::balloonColour_get, &ScGuest::balloonColour_set),
+            JS_CGETSET_DEF("hatColour", &ScGuest::hatColour_get, &ScGuest::hatColour_set),
+            JS_CGETSET_DEF("umbrellaColour", &ScGuest::umbrellaColour_get, &ScGuest::umbrellaColour_set),
+            JS_CGETSET_DEF("happiness", &ScGuest::happiness_get, &ScGuest::happiness_set),
+            JS_CGETSET_DEF("happinessTarget", &ScGuest::happinessTarget_get, &ScGuest::happinessTarget_set),
+            JS_CGETSET_DEF("nausea", &ScGuest::nausea_get, &ScGuest::nausea_set),
+            JS_CGETSET_DEF("nauseaTarget", &ScGuest::nauseaTarget_get, &ScGuest::nauseaTarget_set),
+            JS_CGETSET_DEF("hunger", &ScGuest::hunger_get, &ScGuest::hunger_set),
+            JS_CGETSET_DEF("thirst", &ScGuest::thirst_get, &ScGuest::thirst_set),
+            JS_CGETSET_DEF("toilet", &ScGuest::toilet_get, &ScGuest::toilet_set),
+            JS_CGETSET_DEF("mass", &ScGuest::mass_get, &ScGuest::mass_set),
+            JS_CGETSET_DEF("minIntensity", &ScGuest::minIntensity_get, &ScGuest::minIntensity_set),
+            JS_CGETSET_DEF("maxIntensity", &ScGuest::maxIntensity_get, &ScGuest::maxIntensity_set),
+            JS_CGETSET_DEF("nauseaTolerance", &ScGuest::nauseaTolerance_get, &ScGuest::nauseaTolerance_set),
+            JS_CGETSET_DEF("cash", &ScGuest::cash_get, &ScGuest::cash_set),
+            JS_CGETSET_DEF("isInPark", &ScGuest::isInPark_get, nullptr),
+            JS_CGETSET_DEF("isLost", &ScGuest::isLost_get, nullptr),
+            JS_CGETSET_DEF("lostCountdown", &ScGuest::lostCountdown_get, &ScGuest::lostCountdown_set),
+            JS_CGETSET_DEF("favouriteRide", &ScGuest::favouriteRide_get, &ScGuest::favouriteRide_set),
+            JS_CGETSET_DEF("thoughts", &ScGuest::thoughts_get, nullptr),
+            JS_CGETSET_DEF("items", &ScGuest::items_get, nullptr),
+            JS_CGETSET_DEF("availableAnimations", &ScGuest::availableAnimations_get, nullptr),
+            JS_CGETSET_DEF("animation", &ScGuest::animation_get, &ScGuest::animation_set),
+            JS_CGETSET_DEF("animationOffset", &ScGuest::animationOffset_get, &ScGuest::animationOffset_set),
+            JS_CGETSET_DEF("animationLength", &ScGuest::animationLength_get, nullptr),
+            JS_CFUNC_DEF("getAnimationSpriteIds", 0, &ScGuest::getAnimationSpriteIds),
+            JS_CFUNC_DEF("hasItem", 1, &ScGuest::has_item),
+            JS_CFUNC_DEF("giveItem", 1, &ScGuest::give_item),
+            JS_CFUNC_DEF("removeItem", 1, &ScGuest::remove_item),
+            JS_CFUNC_DEF("removeAllItems", 0, &ScGuest::remove_all_items),
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScGuest::Register(duk_context* ctx)
+    Guest* ScGuest::GetGuest(JSValue thisVal)
     {
-        dukglue_set_base_class<ScPeep, ScGuest>(ctx);
-        dukglue_register_property(ctx, &ScGuest::tshirtColour_get, &ScGuest::tshirtColour_set, "tshirtColour");
-        dukglue_register_property(ctx, &ScGuest::trousersColour_get, &ScGuest::trousersColour_set, "trousersColour");
-        dukglue_register_property(ctx, &ScGuest::balloonColour_get, &ScGuest::balloonColour_set, "balloonColour");
-        dukglue_register_property(ctx, &ScGuest::hatColour_get, &ScGuest::hatColour_set, "hatColour");
-        dukglue_register_property(ctx, &ScGuest::umbrellaColour_get, &ScGuest::umbrellaColour_set, "umbrellaColour");
-        dukglue_register_property(ctx, &ScGuest::happiness_get, &ScGuest::happiness_set, "happiness");
-        dukglue_register_property(ctx, &ScGuest::happinessTarget_get, &ScGuest::happinessTarget_set, "happinessTarget");
-        dukglue_register_property(ctx, &ScGuest::nausea_get, &ScGuest::nausea_set, "nausea");
-        dukglue_register_property(ctx, &ScGuest::nauseaTarget_get, &ScGuest::nauseaTarget_set, "nauseaTarget");
-        dukglue_register_property(ctx, &ScGuest::hunger_get, &ScGuest::hunger_set, "hunger");
-        dukglue_register_property(ctx, &ScGuest::thirst_get, &ScGuest::thirst_set, "thirst");
-        dukglue_register_property(ctx, &ScGuest::toilet_get, &ScGuest::toilet_set, "toilet");
-        dukglue_register_property(ctx, &ScGuest::mass_get, &ScGuest::mass_set, "mass");
-        dukglue_register_property(ctx, &ScGuest::minIntensity_get, &ScGuest::minIntensity_set, "minIntensity");
-        dukglue_register_property(ctx, &ScGuest::maxIntensity_get, &ScGuest::maxIntensity_set, "maxIntensity");
-        dukglue_register_property(ctx, &ScGuest::nauseaTolerance_get, &ScGuest::nauseaTolerance_set, "nauseaTolerance");
-        dukglue_register_property(ctx, &ScGuest::cash_get, &ScGuest::cash_set, "cash");
-        dukglue_register_property(ctx, &ScGuest::isInPark_get, nullptr, "isInPark");
-        dukglue_register_property(ctx, &ScGuest::isLost_get, nullptr, "isLost");
-        dukglue_register_property(ctx, &ScGuest::lostCountdown_get, &ScGuest::lostCountdown_set, "lostCountdown");
-        dukglue_register_property(ctx, &ScGuest::favouriteRide_get, &ScGuest::favouriteRide_set, "favouriteRide");
-        dukglue_register_property(ctx, &ScGuest::thoughts_get, nullptr, "thoughts");
-        dukglue_register_property(ctx, &ScGuest::items_get, nullptr, "items");
-        dukglue_register_property(ctx, &ScGuest::availableAnimations_get, nullptr, "availableAnimations");
-        dukglue_register_property(ctx, &ScGuest::animation_get, &ScGuest::animation_set, "animation");
-        dukglue_register_property(ctx, &ScGuest::animationOffset_get, &ScGuest::animationOffset_set, "animationOffset");
-        dukglue_register_property(ctx, &ScGuest::animationLength_get, nullptr, "animationLength");
-        dukglue_register_method(ctx, &ScGuest::getAnimationSpriteIds, "getAnimationSpriteIds");
-        dukglue_register_method(ctx, &ScGuest::has_item, "hasItem");
-        dukglue_register_method(ctx, &ScGuest::give_item, "giveItem");
-        dukglue_register_method(ctx, &ScGuest::remove_item, "removeItem");
-        dukglue_register_method(ctx, &ScGuest::remove_all_items, "removeAllItems");
+        auto id = GetEntityId(thisVal);
+        return OpenRCT2::GetEntity<Guest>(id);
     }
 
-    Guest* ScGuest::GetGuest() const
+    JSValue ScGuest::tshirtColour_get(JSContext* ctx, JSValue thisVal)
     {
-        return OpenRCT2::GetEntity<Guest>(_id);
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->TshirtColour : 0);
     }
-
-    uint8_t ScGuest::tshirtColour_get() const
+    JSValue ScGuest::tshirtColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->TshirtColour : 0;
-    }
-    void ScGuest::tshirtColour_set(uint8_t value)
-    {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->TshirtColour = value;
             peep->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::trousersColour_get() const
+    JSValue ScGuest::trousersColour_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->TrousersColour : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->TrousersColour : 0);
     }
-    void ScGuest::trousersColour_set(uint8_t value)
+    JSValue ScGuest::trousersColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->TrousersColour = value;
             peep->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::balloonColour_get() const
+    JSValue ScGuest::balloonColour_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->BalloonColour : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->BalloonColour : 0);
     }
-    void ScGuest::balloonColour_set(uint8_t value)
+    JSValue ScGuest::balloonColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->BalloonColour = value;
             peep->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::hatColour_get() const
+    JSValue ScGuest::hatColour_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->HatColour : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->HatColour : 0);
     }
-    void ScGuest::hatColour_set(uint8_t value)
+    JSValue ScGuest::hatColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->HatColour = value;
             peep->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::umbrellaColour_get() const
+    JSValue ScGuest::umbrellaColour_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->UmbrellaColour : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->UmbrellaColour : 0);
     }
-    void ScGuest::umbrellaColour_set(uint8_t value)
+    JSValue ScGuest::umbrellaColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->UmbrellaColour = value;
             peep->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::happiness_get() const
+    JSValue ScGuest::happiness_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->Happiness : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->Happiness : 0);
     }
-    void ScGuest::happiness_set(uint8_t value)
+    JSValue ScGuest::happiness_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->Happiness = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::happinessTarget_get() const
+    JSValue ScGuest::happinessTarget_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->HappinessTarget : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->HappinessTarget : 0);
     }
-    void ScGuest::happinessTarget_set(uint8_t value)
+    JSValue ScGuest::happinessTarget_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->HappinessTarget = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::nausea_get() const
+    JSValue ScGuest::nausea_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->Nausea : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->Nausea : 0);
     }
-    void ScGuest::nausea_set(uint8_t value)
+    JSValue ScGuest::nausea_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->Nausea = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::nauseaTarget_get() const
+    JSValue ScGuest::nauseaTarget_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->NauseaTarget : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->NauseaTarget : 0);
     }
-    void ScGuest::nauseaTarget_set(uint8_t value)
+    JSValue ScGuest::nauseaTarget_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->NauseaTarget = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::hunger_get() const
+    JSValue ScGuest::hunger_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->Hunger : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->Hunger : 0);
     }
-    void ScGuest::hunger_set(uint8_t value)
+    JSValue ScGuest::hunger_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->Hunger = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::thirst_get() const
+    JSValue ScGuest::thirst_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->Thirst : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->Thirst : 0);
     }
-    void ScGuest::thirst_set(uint8_t value)
+    JSValue ScGuest::thirst_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->Thirst = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::toilet_get() const
+    JSValue ScGuest::toilet_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->Toilet : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->Toilet : 0);
     }
-    void ScGuest::toilet_set(uint8_t value)
+    JSValue ScGuest::toilet_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->Toilet = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::mass_get() const
+    JSValue ScGuest::mass_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->Mass : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->Mass : 0);
     }
-    void ScGuest::mass_set(uint8_t value)
+    JSValue ScGuest::mass_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->Mass = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::minIntensity_get() const
+    JSValue ScGuest::minIntensity_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->Intensity.GetMinimum() : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->Intensity.GetMinimum() : 0);
     }
-    void ScGuest::minIntensity_set(uint8_t value)
+    JSValue ScGuest::minIntensity_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->Intensity = peep->Intensity.WithMinimum(value);
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::maxIntensity_get() const
+    JSValue ScGuest::maxIntensity_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->Intensity.GetMaximum() : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->Intensity.GetMaximum() : 0);
     }
-    void ScGuest::maxIntensity_set(uint8_t value)
+    JSValue ScGuest::maxIntensity_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->Intensity = peep->Intensity.WithMaximum(value);
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::nauseaTolerance_get() const
+    JSValue ScGuest::nauseaTolerance_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? EnumValue(peep->NauseaTolerance) : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? EnumValue(peep->NauseaTolerance) : 0);
     }
-    void ScGuest::nauseaTolerance_set(uint8_t value)
+    JSValue ScGuest::nauseaTolerance_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->NauseaTolerance = static_cast<PeepNauseaTolerance>(std::min<uint8_t>(value, 3));
         }
+        return JS_UNDEFINED;
     }
 
-    int32_t ScGuest::cash_get() const
+    JSValue ScGuest::cash_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->CashInPocket : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewInt32(ctx, peep != nullptr ? peep->CashInPocket : 0);
     }
-    void ScGuest::cash_set(int32_t value)
+    JSValue ScGuest::cash_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_INT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->CashInPocket = std::max(0, value);
         }
+        return JS_UNDEFINED;
     }
 
-    bool ScGuest::isInPark_get() const
+    JSValue ScGuest::isInPark_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return (peep != nullptr && !peep->OutsideOfPark);
+        auto peep = GetGuest(thisVal);
+        return JS_NewBool(ctx, peep != nullptr && !peep->OutsideOfPark);
     }
 
-    bool ScGuest::isLost_get() const
+    JSValue ScGuest::isLost_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return (peep != nullptr && peep->GuestIsLostCountdown < 90);
+        auto peep = GetGuest(thisVal);
+        return JS_NewBool(ctx, peep != nullptr && peep->GuestIsLostCountdown < 90);
     }
 
-    uint8_t ScGuest::lostCountdown_get() const
+    JSValue ScGuest::lostCountdown_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetGuest();
-        return peep != nullptr ? peep->GuestIsLostCountdown : 0;
+        auto peep = GetGuest(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->GuestIsLostCountdown : 0);
     }
-    void ScGuest::lostCountdown_set(uint8_t value)
+    JSValue ScGuest::lostCountdown_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->GuestIsLostCountdown = value;
         }
+        return JS_UNDEFINED;
     }
 
-    DukValue ScGuest::favouriteRide_get() const
+    JSValue ScGuest::favouriteRide_get(JSContext* ctx, JSValue thisVal)
     {
-        auto& scriptEngine = GetContext()->GetScriptEngine();
-        auto* ctx = scriptEngine.GetContext();
-        auto peep = GetGuest();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             if (peep->FavouriteRide != RideId::GetNull())
             {
-                duk_push_int(ctx, peep->FavouriteRide.ToUnderlying());
-            }
-            else
-            {
-                duk_push_null(ctx);
+                return JS_NewUint32(ctx, peep->FavouriteRide.ToUnderlying());
             }
         }
-        else
-        {
-            duk_push_null(ctx);
-        }
-        return DukValue::take_from_stack(ctx);
+        return JS_NULL;
     }
 
-    void ScGuest::favouriteRide_set(const DukValue& value)
+    JSValue ScGuest::favouriteRide_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             auto& gameState = getGameState();
-            if (value.type() == DukValue::Type::NUMBER && value.as_uint() < gameState.rides.size()
-                && gameState.rides[value.as_uint()].type != kRideTypeNull)
-            {
-                peep->FavouriteRide = RideId::FromUnderlying(value.as_uint());
-            }
-            else
+            if (JS_IsNull(jsValue))
             {
                 peep->FavouriteRide = RideId::GetNull();
             }
+            else if (JS_IsNumber(jsValue))
+            {
+                JS_UNPACK_UINT32(rideId, ctx, jsValue);
+                if (rideId < gameState.rides.size() && gameState.rides[rideId].type != kRideTypeNull)
+                {
+                    peep->FavouriteRide = RideId::FromUnderlying(rideId);
+                }
+            }
         }
+        return JS_UNDEFINED;
     }
 
-    DukValue ScGuest::thoughts_get() const
+    JSValue ScGuest::thoughts_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
+        auto array = JS_NewArray(ctx);
 
-        duk_push_array(ctx);
-
-        auto peep = GetGuest();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
-            duk_uarridx_t index = 0;
+            auto index = 0;
             for (const auto& thought : peep->Thoughts)
             {
                 if (thought.type == PeepThoughtType::None)
                     break;
                 if (thought.freshness == 0)
                     continue;
-                auto scThoughtPtr = std::make_shared<ScThought>(thought);
-                auto dukThought = GetObjectAsDukValue(ctx, scThoughtPtr);
-                dukThought.push();
-                duk_put_prop_index(ctx, -2, index);
-                index++;
+                auto scThought = gScThought.New(ctx, thought);
+                JS_SetPropertyInt64(ctx, array, index++, scThought);
             }
         }
 
-        return DukValue::take_from_stack(ctx, -1);
+        return array;
     }
 
-    DukValue ScGuest::items_get() const
+    JSValue ScGuest::items_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
+        auto array = JS_NewArray(ctx);
 
-        duk_push_array(ctx);
-
-        auto peep = GetGuest();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
-            duk_uarridx_t index = 0;
+            auto index = 0;
             for (const auto& itemEnumPair : ShopItemMap)
             {
                 auto shopItem = itemEnumPair.second;
@@ -572,72 +592,74 @@ namespace OpenRCT2::Scripting
                 }
 
                 // GuestItem
-                auto obj = OpenRCT2::Scripting::DukObject(ctx);
-                obj.Set("type", itemEnumPair.first);
+                auto obj = JS_NewObject(ctx);
+                JS_SetPropertyStr(ctx, obj, "type", JSFromStdString(ctx, itemEnumPair.first));
 
                 if (shopItem == ShopItem::Voucher)
                 {
                     // Voucher
-                    obj.Set("voucherType", VoucherTypeMap[peep->VoucherType]);
+                    JS_SetPropertyStr(ctx, obj, "voucherType", JSFromStdString(ctx, VoucherTypeMap[peep->VoucherType]));
                     if (peep->VoucherType == VOUCHER_TYPE_RIDE_FREE)
                     {
                         // RideVoucher
-                        obj.Set("rideId", peep->VoucherRideId.ToUnderlying());
+                        JS_SetPropertyStr(ctx, obj, "rideId", JS_NewUint32(ctx, peep->VoucherRideId.ToUnderlying()));
                     }
                     else if (peep->VoucherType == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
                     {
                         // FoodDrinkVoucher
-                        obj.Set("item", ShopItemMap[peep->VoucherShopItem]);
+                        JS_SetPropertyStr(ctx, obj, "item", JSFromStdString(ctx, ShopItemMap[peep->VoucherShopItem]));
                     }
                 }
                 else if (GetShopItemDescriptor(shopItem).IsPhoto())
                 {
                     // GuestPhoto
+                    RideId rideId;
                     switch (shopItem)
                     {
                         case ShopItem::Photo:
-                            obj.Set("rideId", peep->Photo1RideRef.ToUnderlying());
+                            rideId = peep->Photo1RideRef;
                             break;
                         case ShopItem::Photo2:
-                            obj.Set("rideId", peep->Photo2RideRef.ToUnderlying());
+                            rideId = peep->Photo2RideRef;
                             break;
                         case ShopItem::Photo3:
-                            obj.Set("rideId", peep->Photo3RideRef.ToUnderlying());
+                            rideId = peep->Photo3RideRef;
                             break;
                         case ShopItem::Photo4:
-                            obj.Set("rideId", peep->Photo4RideRef.ToUnderlying());
+                            rideId = peep->Photo4RideRef;
                             break;
                         default:
                             // This should not be possible
-                            duk_error(ctx, DUK_ERR_TYPE_ERROR, "Item is photo without a ride ref.");
+                            JS_ThrowPlainError(ctx, "Item is photo without a ride ref.");
+                            return JS_EXCEPTION;
                     }
+
+                    JS_SetPropertyStr(ctx, obj, "rideId", JS_NewUint32(ctx, rideId.ToUnderlying()));
                 }
 
-                auto dukItem = obj.Take();
-                dukItem.push();
-                duk_put_prop_index(ctx, -2, index);
-                index++;
+                JS_SetPropertyInt64(ctx, array, index++, obj);
             }
         }
 
-        return DukValue::take_from_stack(ctx, -1);
+        return array;
     }
 
-    bool ScGuest::has_item(const DukValue& item) const
+    bool ScGuest::has_item(JSContext* ctx, JSValue thisVal, JSValue item)
     {
-        auto peep = GetGuest();
+        auto peep = GetGuest(thisVal);
         if (peep == nullptr)
         {
             return false;
         }
 
-        if (item["type"].type() != DukValue::Type::STRING)
+        auto type = JSToOptionalStdString(ctx, item, "type");
+        if (!type.has_value())
         {
             return false;
         }
 
         // GuestItem
-        auto shopItem = ShopItemMap.TryGet(item["type"].as_string());
+        auto shopItem = ShopItemMap.TryGet(type.value());
         if (!shopItem || !peep->HasItem(*shopItem))
         {
             return false;
@@ -645,10 +667,11 @@ namespace OpenRCT2::Scripting
 
         if (*shopItem == ShopItem::Voucher)
         {
-            if (item["voucherType"].type() == DukValue::Type::STRING)
+            auto voucherType = JSToOptionalStdString(ctx, item, "voucherType");
+            if (voucherType.has_value())
             {
                 // Voucher
-                auto voucher = VoucherTypeMap.TryGet(item["voucherType"].as_string());
+                auto voucher = VoucherTypeMap.TryGet(voucherType.value());
                 if (!voucher || *voucher != peep->VoucherType)
                 {
                     return false;
@@ -656,10 +679,11 @@ namespace OpenRCT2::Scripting
 
                 if (*voucher == VOUCHER_TYPE_RIDE_FREE)
                 {
-                    if (item["rideId"].type() == DukValue::Type::NUMBER)
+                    auto rideId = JSToOptionalUint(ctx, item, "rideId");
+                    if (rideId.has_value())
                     {
                         // RideVoucher
-                        if (item["rideId"].as_uint() != peep->VoucherRideId.ToUnderlying())
+                        if (rideId.value() != peep->VoucherRideId.ToUnderlying())
                         {
                             return false;
                         }
@@ -667,10 +691,11 @@ namespace OpenRCT2::Scripting
                 }
                 else if (*voucher == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
                 {
-                    if (item["item"].type() == DukValue::Type::STRING)
+                    auto foodItem = JSToOptionalStdString(ctx, item, "item");
+                    if (foodItem.has_value())
                     {
                         // FoodDrinkVoucher
-                        auto voucherItem = ShopItemMap.TryGet(item["item"].as_string());
+                        auto voucherItem = ShopItemMap.TryGet(foodItem.value());
                         if (!voucherItem || *voucherItem != peep->VoucherShopItem)
                         {
                             return false;
@@ -682,30 +707,31 @@ namespace OpenRCT2::Scripting
         else if (GetShopItemDescriptor(*shopItem).IsPhoto())
         {
             // GuestPhoto
-            if (item["rideId"].type() == DukValue::Type::NUMBER)
+            auto rideId = JSToOptionalUint(ctx, item, "rideId");
+            if (rideId.has_value())
             {
                 switch (*shopItem)
                 {
                     case ShopItem::Photo:
-                        if (item["rideId"].as_uint() != peep->Photo1RideRef.ToUnderlying())
+                        if (rideId.value() != peep->Photo1RideRef.ToUnderlying())
                         {
                             return false;
                         }
                         break;
                     case ShopItem::Photo2:
-                        if (item["rideId"].as_uint() != peep->Photo2RideRef.ToUnderlying())
+                        if (rideId.value() != peep->Photo2RideRef.ToUnderlying())
                         {
                             return false;
                         }
                         break;
                     case ShopItem::Photo3:
-                        if (item["rideId"].as_uint() != peep->Photo3RideRef.ToUnderlying())
+                        if (rideId.value() != peep->Photo3RideRef.ToUnderlying())
                         {
                             return false;
                         }
                         break;
                     case ShopItem::Photo4:
-                        if (item["rideId"].as_uint() != peep->Photo4RideRef.ToUnderlying())
+                        if (rideId.value() != peep->Photo4RideRef.ToUnderlying())
                         {
                             return false;
                         }
@@ -715,74 +741,86 @@ namespace OpenRCT2::Scripting
                 }
             }
         }
-
         return true;
     }
 
-    void ScGuest::give_item(const DukValue& item) const
+    JSValue ScGuest::has_item(JSContext * ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_UNPACK_OBJECT(item, ctx, argv[1]); // todo out of bounds?
+        auto result = has_item(ctx, thisVal, item);
+        return JS_NewBool(ctx, result);
+    }
+
+    JSValue ScGuest::give_item(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
+    {
+        JS_UNPACK_OBJECT(item, ctx, argv[1]); // todo out of bounds?
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+
+        auto peep = GetGuest(thisVal);
         if (peep == nullptr)
         {
-            return;
+            return JS_UNDEFINED;
         }
 
         // GuestItem
-        if (item["type"].type() != DukValue::Type::STRING)
+        auto type = JSToOptionalStdString(ctx, item, "type");
+        if (!type.has_value())
         {
-            auto ctx = GetContext()->GetScriptEngine().GetContext();
-            duk_error(ctx, DUK_ERR_ERROR, "Invalid 'type'.");
+            JS_ThrowPlainError(ctx, "Invalid 'type'.");
+            return JS_EXCEPTION;
         }
 
-        auto shopItem = ShopItemMap.TryGet(item["type"].as_string());
+        auto shopItem = ShopItemMap.TryGet(type.value());
         if (!shopItem)
         {
-            auto ctx = GetContext()->GetScriptEngine().GetContext();
-            duk_error(ctx, DUK_ERR_ERROR, "Invalid 'type'.");
+            JS_ThrowPlainError(ctx, "Invalid 'type'.");
+            return JS_EXCEPTION;
         }
 
         if (*shopItem == ShopItem::Voucher)
         {
             // Voucher
-            if (item["voucherType"].type() != DukValue::Type::STRING)
+            auto voucherTypeName = JSToOptionalStdString(ctx, item, "voucherType");
+            if (!voucherTypeName.has_value())
             {
-                auto ctx = GetContext()->GetScriptEngine().GetContext();
-                duk_error(ctx, DUK_ERR_ERROR, "Invalid 'voucherType'.");
+                JS_ThrowPlainError(ctx, "Invalid 'voucherType'.");
+                return JS_EXCEPTION;
             }
 
-            auto voucherType = VoucherTypeMap.TryGet(item["voucherType"].as_string());
+            auto voucherType = VoucherTypeMap.TryGet(voucherTypeName.value());
             if (!voucherType)
             {
-                auto ctx = GetContext()->GetScriptEngine().GetContext();
-                duk_error(ctx, DUK_ERR_ERROR, "Invalid 'voucherType'.");
+                JS_ThrowPlainError(ctx, "Invalid 'voucherType'.");
+                return JS_EXCEPTION;
             }
 
             if (*voucherType == VOUCHER_TYPE_RIDE_FREE)
             {
                 // RideVoucher
-                if (item["rideId"].type() != DukValue::Type::NUMBER)
+                auto rideId = JSToOptionalUint(ctx, item, "rideId");
+                if (!rideId.has_value())
                 {
-                    auto ctx = GetContext()->GetScriptEngine().GetContext();
-                    duk_error(ctx, DUK_ERR_ERROR, "Invalid 'rideId'.");
+                    JS_ThrowPlainError(ctx, "Invalid 'rideId'.");
+                    return JS_EXCEPTION;
                 }
 
-                peep->VoucherRideId = RideId::FromUnderlying(item["rideId"].as_uint());
+                peep->VoucherRideId = RideId::FromUnderlying(rideId.value());
             }
             else if (*voucherType == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
             {
                 // FoodDrinkVoucher
-                if (item["item"].type() != DukValue::Type::STRING)
+                auto itemName = JSToOptionalStdString(ctx, item, "item");
+                if (!itemName.has_value())
                 {
-                    auto ctx = GetContext()->GetScriptEngine().GetContext();
-                    duk_error(ctx, DUK_ERR_ERROR, "Invalid 'item' (for food/drink voucher).");
+                    JS_ThrowPlainError(ctx, "Invalid 'item' (for food/drink voucher).");
+                    return JS_EXCEPTION;
                 }
 
-                auto voucherItem = ShopItemMap.TryGet(item["item"].as_string());
+                auto voucherItem = ShopItemMap.TryGet(itemName.value());
                 if (!voucherItem)
                 {
-                    auto ctx = GetContext()->GetScriptEngine().GetContext();
-                    duk_error(ctx, DUK_ERR_ERROR, "Invalid 'item' (for food/drink voucher).");
+                    JS_ThrowPlainError(ctx, "Invalid 'item' (for food/drink voucher).");
+                    return JS_EXCEPTION;
                 }
 
                 peep->VoucherShopItem = *voucherItem;
@@ -793,71 +831,81 @@ namespace OpenRCT2::Scripting
         else if (GetShopItemDescriptor(*shopItem).IsPhoto())
         {
             // GuestPhoto
-            if (item["rideId"].type() != DukValue::Type::NUMBER)
+            auto rideId = JSToOptionalUint(ctx, item, "rideId");
+            if (!rideId.has_value())
             {
-                auto ctx = GetContext()->GetScriptEngine().GetContext();
-                duk_error(ctx, DUK_ERR_ERROR, "Invalid 'rideId'.");
+                JS_ThrowPlainError(ctx, "Invalid 'rideId'.");
+                return JS_EXCEPTION;
             }
 
             switch (*shopItem)
             {
                 case ShopItem::Photo:
-                    peep->Photo1RideRef = RideId::FromUnderlying(item["rideId"].as_uint());
+                    peep->Photo1RideRef = RideId::FromUnderlying(rideId.value());
                     break;
                 case ShopItem::Photo2:
-                    peep->Photo2RideRef = RideId::FromUnderlying(item["rideId"].as_uint());
+                    peep->Photo2RideRef = RideId::FromUnderlying(rideId.value());
                     break;
                 case ShopItem::Photo3:
-                    peep->Photo3RideRef = RideId::FromUnderlying(item["rideId"].as_uint());
+                    peep->Photo3RideRef = RideId::FromUnderlying(rideId.value());
                     break;
                 case ShopItem::Photo4:
-                    peep->Photo4RideRef = RideId::FromUnderlying(item["rideId"].as_uint());
+                    peep->Photo4RideRef = RideId::FromUnderlying(rideId.value());
                     break;
                 default:
-                    return;
+                    return JS_UNDEFINED;
             }
         }
 
         peep->GiveItem(*shopItem);
         peep->UpdateAnimationGroup();
+        return JS_UNDEFINED;
     }
 
-    void ScGuest::remove_item(const DukValue& item) const
+    JSValue ScGuest::remove_item(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        ThrowIfGameStateNotMutable();
-        if (has_item(item))
+        JS_UNPACK_OBJECT(item, ctx, argv[1]); // todo out of bounds?
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        if (has_item(ctx, thisVal, item))
         {
+            auto type = JSToStdString(ctx, item, "type");
+
             // Since guests can only have one item of a type and this item matches, remove it.
-            auto peep = GetGuest();
-            peep->RemoveItem(ShopItemMap[item["type"].as_string()]);
+            auto peep = GetGuest(thisVal);
+            peep->RemoveItem(ShopItemMap[type]);
             peep->UpdateAnimationGroup();
         }
+        return JS_UNDEFINED;
     }
 
-    void ScGuest::remove_all_items() const
+    JSValue ScGuest::remove_all_items(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetGuest();
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             peep->RemoveAllItems();
             peep->UpdateAnimationGroup();
         }
+        return JS_UNDEFINED;
     }
 
-    std::vector<std::string> ScGuest::availableAnimations_get() const
+    JSValue ScGuest::availableAnimations_get(JSContext* ctx, JSValue thisVal)
     {
-        std::vector<std::string> availableAnimations{};
+        auto availableAnimations = JS_NewArray(ctx);
+        auto index = 0;
         for (auto& animation : getAnimationsByPeepType(AnimationPeepType::Guest))
         {
-            availableAnimations.push_back(std::string(animation.first));
+            JS_SetPropertyInt64(ctx, availableAnimations, index++, JSFromStdString(ctx, animation.first));
         }
         return availableAnimations;
     }
 
-    std::vector<uint32_t> ScGuest::getAnimationSpriteIds(std::string groupKey, uint8_t rotation) const
+    JSValue ScGuest::getAnimationSpriteIds(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        std::vector<uint32_t> spriteIds{};
+        JS_UNPACK_STR(groupKey, ctx, argv[1]);
+        JS_UNPACK_UINT32(rotation, ctx, argv[2]);
+        JSValue spriteIds = JS_NewArray(ctx);
 
         auto& availableGuestAnimations = getAnimationsByPeepType(AnimationPeepType::Guest);
         auto animationType = availableGuestAnimations.TryGet(groupKey);
@@ -866,13 +914,14 @@ namespace OpenRCT2::Scripting
             return spriteIds;
         }
 
-        auto peep = GetPeep();
+        auto peep = GetPeep(thisVal);
         if (peep != nullptr)
         {
             auto& objManager = GetContext()->GetObjectManager();
             auto* animObj = objManager.GetLoadedObject<PeepAnimationsObject>(peep->AnimationObjectIndex);
 
             const auto& animationGroup = animObj->GetPeepAnimation(peep->AnimationGroup, *animationType);
+            auto idx = 0;
             for (auto frameOffset : animationGroup.frame_offsets)
             {
                 auto imageId = animationGroup.base_image;
@@ -881,18 +930,19 @@ namespace OpenRCT2::Scripting
                 else
                     imageId += frameOffset;
 
-                spriteIds.push_back(imageId);
+                JS_SetPropertyInt64(ctx, spriteIds, idx++, JS_NewUint32(ctx, imageId));
+
             }
         }
         return spriteIds;
     }
 
-    std::string ScGuest::animation_get() const
+    JSValue ScGuest::animation_get(JSContext* ctx, JSValue thisVal)
     {
-        auto* peep = GetGuest();
+        auto* peep = GetGuest(thisVal);
         if (peep == nullptr)
         {
-            return nullptr;
+            return JS_NULL;
         }
 
         auto& availableGuestAnimations = getAnimationsByPeepType(AnimationPeepType::Guest);
@@ -903,21 +953,23 @@ namespace OpenRCT2::Scripting
         if (peep->AnimationType == PeepAnimationType::Walking && peep->State == PeepState::Sitting)
             action = availableGuestAnimations[PeepAnimationType::SittingIdle];
 
-        return std::string(action);
+        return JSFromStdString(ctx, action);
     }
 
-    void ScGuest::animation_set(std::string groupKey)
+    JSValue ScGuest::animation_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
+        JS_UNPACK_STR(groupKey, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto& availableGuestAnimations = getAnimationsByPeepType(AnimationPeepType::Guest);
         auto newType = availableGuestAnimations.TryGet(groupKey);
         if (newType == std::nullopt)
         {
-            throw DukException() << "Invalid animation for this guest (" << groupKey << ")";
+            JS_ThrowPlainError(ctx, "Invalid animation for this guest (%s)", groupKey.data());
+            return JS_EXCEPTION;
         }
 
-        auto* peep = GetGuest();
+        auto* peep = GetGuest(thisVal);
         peep->AnimationType = peep->NextAnimationType = *newType;
 
         auto offset = 0;
@@ -934,27 +986,27 @@ namespace OpenRCT2::Scripting
         peep->Invalidate();
         peep->UpdateSpriteBoundingBox();
         peep->Invalidate();
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::animationOffset_get() const
+    JSValue ScGuest::animationOffset_get(JSContext* ctx, JSValue thisVal)
     {
-        auto* peep = GetGuest();
+        auto* peep = GetGuest(thisVal);
         if (peep == nullptr)
         {
-            return 0;
+            return JS_NewUint32(ctx, 0);
         }
 
-        if (peep->IsActionWalking())
-            return peep->WalkingAnimationFrameNum;
-        else
-            return peep->AnimationFrameNum;
+        auto frame = peep->IsActionWalking() ? peep->WalkingAnimationFrameNum : peep->AnimationFrameNum;
+        return JS_NewUint32(ctx, frame);
     }
 
-    void ScGuest::animationOffset_set(uint8_t offset)
+    JSValue ScGuest::animationOffset_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
+        JS_UNPACK_UINT32(offset, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
-        auto* peep = GetGuest();
+        auto* peep = GetGuest(thisVal);
 
         auto& objManager = GetContext()->GetObjectManager();
         auto* animObj = objManager.GetLoadedObject<PeepAnimationsObject>(peep->AnimationObjectIndex);
@@ -970,63 +1022,93 @@ namespace OpenRCT2::Scripting
 
         peep->AnimationImageIdOffset = animationGroup.frame_offsets[offset];
         peep->UpdateSpriteBoundingBox();
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScGuest::animationLength_get() const
+    JSValue ScGuest::animationLength_get(JSContext* ctx, JSValue thisVal)
     {
-        auto* peep = GetGuest();
+        auto* peep = GetGuest(thisVal);
         if (peep == nullptr)
         {
-            return 0;
+            return JS_NewUint32(ctx, 0);
         }
 
         auto& objManager = GetContext()->GetObjectManager();
         auto* animObj = objManager.GetLoadedObject<PeepAnimationsObject>(peep->AnimationObjectIndex);
 
         const auto& animationGroup = animObj->GetPeepAnimation(peep->AnimationGroup, peep->AnimationType);
-        return static_cast<uint8_t>(animationGroup.frame_offsets.size());
+        return JS_NewUint32(ctx, static_cast<uint32_t>(animationGroup.frame_offsets.size()));
     }
 
-    ScThought::ScThought(PeepThought backing)
-        : _backing(backing)
+    extern ScThought gScThought;
+
+    using OpaqueThoughtData = struct
     {
+        PeepThought thought;
+    };
+
+    JSValue ScThought::New(JSContext* ctx, PeepThought thought)
+    {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("type", &ScThought::type_get, nullptr),
+            JS_CGETSET_DEF("item", &ScThought::item_get, nullptr),
+            JS_CGETSET_DEF("freshness", &ScThought::freshness_get, nullptr),
+            JS_CGETSET_DEF("freshTimeout", &ScThought::freshTimeout_get, nullptr),
+            JS_CFUNC_DEF("toString", 0, &ScThought::toString),
+        };
+        return MakeWithOpaque(ctx, funcs, new OpaqueThoughtData{ thought });
     }
 
-    void ScThought::Register(duk_context* ctx)
+    void ScThought::Register(JSContext* ctx)
     {
-        dukglue_register_property(ctx, &ScThought::type_get, nullptr, "type");
-        dukglue_register_property(ctx, &ScThought::item_get, nullptr, "item");
-        dukglue_register_property(ctx, &ScThought::freshness_get, nullptr, "freshness");
-        dukglue_register_property(ctx, &ScThought::freshTimeout_get, nullptr, "freshTimeout");
-        dukglue_register_method(ctx, &ScThought::toString, "toString");
+        RegisterBaseStr(ctx, "Thought", Finalize);
     }
 
-    std::string ScThought::type_get() const
+    void ScThought::Finalize(JSRuntime* rt, JSValue thisVal)
     {
-        return std::string(ThoughtTypeMap[_backing.type]);
+        OpaqueThoughtData* data = gScThought.GetOpaque<OpaqueThoughtData*>(thisVal);
+        if (data)
+            delete data;
     }
 
-    uint16_t ScThought::item_get() const
+    PeepThought ScThought::GetThought(JSValue thisVal)
     {
-        return _backing.item;
+        OpaqueThoughtData* data = gScThought.GetOpaque<OpaqueThoughtData*>(thisVal);
+        return data->thought;
     }
 
-    uint8_t ScThought::freshness_get() const
+    JSValue ScThought::type_get(JSContext* ctx, JSValue thisVal)
     {
-        return _backing.freshness;
+        auto thought = GetThought(thisVal);
+        return JSFromStdString(ctx, ThoughtTypeMap[thought.type]);
     }
 
-    uint8_t ScThought::freshTimeout_get() const
+    JSValue ScThought::item_get(JSContext* ctx, JSValue thisVal)
     {
-        return _backing.fresh_timeout;
+        auto thought = GetThought(thisVal);
+        return JS_NewUint32(ctx, thought.item);
     }
 
-    std::string ScThought::toString() const
+    JSValue ScThought::freshness_get(JSContext* ctx, JSValue thisVal)
     {
+        auto thought = GetThought(thisVal);
+        return JS_NewUint32(ctx, thought.freshness);
+    }
+
+    JSValue ScThought::freshTimeout_get(JSContext* ctx, JSValue thisVal)
+    {
+        auto thought = GetThought(thisVal);
+        return JS_NewUint32(ctx, thought.fresh_timeout);
+    }
+
+    JSValue ScThought::toString(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
+    {
+        auto thought = GetThought(thisVal);
         // format string with arguments
         auto ft = Formatter();
-        PeepThoughtSetFormatArgs(&_backing, ft);
-        return FormatStringIDLegacy(STR_STRINGID, ft.Data());
+        PeepThoughtSetFormatArgs(&thought, ft);
+        auto result = FormatStringIDLegacy(STR_STRINGID, ft.Data());
+        return JSFromStdString(ctx, result);
     }
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/entity/ScGuest.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "../../../entity/Guest.h"
     #include "../../../management/Marketing.h"
@@ -19,7 +19,7 @@ enum class PeepAnimationType : uint8_t;
 
 namespace OpenRCT2::Scripting
 {
-    static const DukEnumMap<ShopItem> ShopItemMap(
+    static const EnumMap<ShopItem> ShopItemMap(
         {
             { "beef_noodles", ShopItem::BeefNoodles },
             { "burger", ShopItem::Burger },
@@ -76,7 +76,7 @@ namespace OpenRCT2::Scripting
     // guest cannot carry), 6 is subtracted from the value.
     static_assert((EnumValue(ShopItem::Count) - 6) == 50, "ShopItem::Count changed, update scripting binding!");
 
-    static const DukEnumMap<uint32_t> VoucherTypeMap(
+    static const EnumMap<uint32_t> VoucherTypeMap(
         {
             { "entry_free", VOUCHER_TYPE_PARK_ENTRY_FREE },
             { "entry_half_price", VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE },
@@ -84,110 +84,111 @@ namespace OpenRCT2::Scripting
             { "food_drink_free", VOUCHER_TYPE_FOOD_OR_DRINK_FREE },
         });
 
-    class ScThought
+    class ScThought;
+    extern ScThought gScThought;
+
+    class ScThought final : public ScBase
     {
-    private:
-        PeepThought _backing;
-
     public:
-        ScThought(PeepThought backing);
-
-        static void Register(duk_context* ctx);
+        JSValue New(JSContext* ctx, PeepThought thought);
+        void Register(JSContext* ctx);
 
     private:
-        std::string type_get() const;
-        uint16_t item_get() const;
-        uint8_t freshness_get() const;
-        uint8_t freshTimeout_get() const;
-        std::string toString() const;
+        static void Finalize(JSRuntime* rt, JSValue thisVal);
+        static PeepThought GetThought(JSValue thisVal);
+
+        static JSValue type_get(JSContext* ctx, JSValue thisVal);
+        static JSValue item_get(JSContext* ctx, JSValue thisVal);
+        static JSValue freshness_get(JSContext* ctx, JSValue thisVal);
+        static JSValue freshTimeout_get(JSContext* ctx, JSValue thisVal);
+        static JSValue toString(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
     };
 
-    class ScGuest : public ScPeep
+    class ScGuest final : public ScPeep
     {
     public:
-        ScGuest(EntityId id);
-
-        static void Register(duk_context* ctx);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
     private:
-        Guest* GetGuest() const;
+        static Guest* GetGuest(JSValue thisVal);
 
-        uint8_t tshirtColour_get() const;
-        void tshirtColour_set(uint8_t value);
+        static JSValue tshirtColour_get(JSContext* ctx, JSValue thisVal);
+        static JSValue tshirtColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t trousersColour_get() const;
-        void trousersColour_set(uint8_t value);
+        static JSValue trousersColour_get(JSContext* ctx, JSValue thisVal);
+        static JSValue trousersColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t balloonColour_get() const;
-        void balloonColour_set(uint8_t value);
+        static JSValue balloonColour_get(JSContext* ctx, JSValue thisVal);
+        static JSValue balloonColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t hatColour_get() const;
-        void hatColour_set(uint8_t value);
+        static JSValue hatColour_get(JSContext* ctx, JSValue thisVal);
+        static JSValue hatColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t umbrellaColour_get() const;
-        void umbrellaColour_set(uint8_t value);
+        static JSValue umbrellaColour_get(JSContext* ctx, JSValue thisVal);
+        static JSValue umbrellaColour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t happiness_get() const;
-        void happiness_set(uint8_t value);
+        static JSValue happiness_get(JSContext* ctx, JSValue thisVal);
+        static JSValue happiness_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t happinessTarget_get() const;
-        void happinessTarget_set(uint8_t value);
+        static JSValue happinessTarget_get(JSContext* ctx, JSValue thisVal);
+        static JSValue happinessTarget_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t nausea_get() const;
-        void nausea_set(uint8_t value);
+        static JSValue nausea_get(JSContext* ctx, JSValue thisVal);
+        static JSValue nausea_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t nauseaTarget_get() const;
-        void nauseaTarget_set(uint8_t value);
+        static JSValue nauseaTarget_get(JSContext* ctx, JSValue thisVal);
+        static JSValue nauseaTarget_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t hunger_get() const;
-        void hunger_set(uint8_t value);
+        static JSValue hunger_get(JSContext* ctx, JSValue thisVal);
+        static JSValue hunger_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t thirst_get() const;
-        void thirst_set(uint8_t value);
+        static JSValue thirst_get(JSContext* ctx, JSValue thisVal);
+        static JSValue thirst_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t toilet_get() const;
-        void toilet_set(uint8_t value);
+        static JSValue toilet_get(JSContext* ctx, JSValue thisVal);
+        static JSValue toilet_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t mass_get() const;
-        void mass_set(uint8_t value);
+        static JSValue mass_get(JSContext* ctx, JSValue thisVal);
+        static JSValue mass_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t minIntensity_get() const;
-        void minIntensity_set(uint8_t value);
+        static JSValue minIntensity_get(JSContext* ctx, JSValue thisVal);
+        static JSValue minIntensity_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t maxIntensity_get() const;
-        void maxIntensity_set(uint8_t value);
+        static JSValue maxIntensity_get(JSContext* ctx, JSValue thisVal);
+        static JSValue maxIntensity_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t nauseaTolerance_get() const;
-        void nauseaTolerance_set(uint8_t value);
+        static JSValue nauseaTolerance_get(JSContext* ctx, JSValue thisVal);
+        static JSValue nauseaTolerance_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        int32_t cash_get() const;
-        void cash_set(int32_t value);
+        static JSValue cash_get(JSContext* ctx, JSValue thisVal);
+        static JSValue cash_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        bool isInPark_get() const;
+        static JSValue isInPark_get(JSContext* ctx, JSValue thisVal);
 
-        bool isLost_get() const;
+        static JSValue isLost_get(JSContext* ctx, JSValue thisVal);
 
-        uint8_t lostCountdown_get() const;
-        void lostCountdown_set(uint8_t value);
+        static JSValue lostCountdown_get(JSContext* ctx, JSValue thisVal);
+        static JSValue lostCountdown_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        DukValue favouriteRide_get() const;
-        void favouriteRide_set(const DukValue& value);
+        static JSValue favouriteRide_get(JSContext* ctx, JSValue thisVal);
+        static JSValue favouriteRide_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        DukValue thoughts_get() const;
+        static JSValue thoughts_get(JSContext* ctx, JSValue thisVal);
 
-        DukValue items_get() const;
-        bool has_item(const DukValue& item) const;
-        void give_item(const DukValue& item) const;
-        void remove_item(const DukValue& item) const;
-        void remove_all_items() const;
+        static JSValue items_get(JSContext* ctx, JSValue thisVal);
+        static bool has_item(JSContext* ctx, JSValue thisVal, JSValue jsValue);
+        static JSValue has_item(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
+        static JSValue give_item(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
+        static JSValue remove_item(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
+        static JSValue remove_all_items(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
 
-        std::vector<std::string> availableAnimations_get() const;
-        std::vector<uint32_t> getAnimationSpriteIds(std::string groupKey, uint8_t rotation) const;
-        std::string animation_get() const;
-        void animation_set(std::string groupKey);
-        uint8_t animationOffset_get() const;
-        void animationOffset_set(uint8_t offset);
-        uint8_t animationLength_get() const;
+        static JSValue availableAnimations_get(JSContext* ctx, JSValue thisVal);
+        static JSValue getAnimationSpriteIds(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
+        static JSValue animation_get(JSContext* ctx, JSValue thisVal);
+        static JSValue animation_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
+        static JSValue animationOffset_get(JSContext* ctx, JSValue thisVal);
+        static JSValue animationOffset_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
+        static JSValue animationLength_get(JSContext* ctx, JSValue thisVal);
     };
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/entity/ScLitter.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScLitter.cpp
@@ -31,9 +31,6 @@ namespace OpenRCT2::Scripting
         { "empty_bowl_blue", Litter::Type::EmptyBowlBlue },
     });
 
-    class ScEntity;
-    extern ScEntity gScEntity;
-
     void ScLitter::AddFuncs(JSContext* ctx, JSValue obj)
     {
         static constexpr JSCFunctionListEntry funcs[] = {

--- a/src/openrct2/scripting/bindings/entity/ScLitter.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScLitter.cpp
@@ -57,7 +57,7 @@ namespace OpenRCT2::Scripting
             auto it = LitterTypeMap.find(litter->SubType);
             if (it != LitterTypeMap.end())
             {
-                return JS_NewString(ctx, it->first.data());
+                return JSFromStdString(ctx, it->first);
             }
         }
         return JS_UNDEFINED;

--- a/src/openrct2/scripting/bindings/entity/ScLitter.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScLitter.cpp
@@ -7,81 +7,82 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "ScLitter.hpp"
 
+    #include "../../../core/EnumMap.hpp"
     #include "../../../entity/Litter.h"
 
 namespace OpenRCT2::Scripting
 {
-    static const DukEnumMap<Litter::Type> LitterTypeMap(
-        {
-            { "vomit", Litter::Type::Vomit },
-            { "vomit_alt", Litter::Type::VomitAlt },
-            { "empty_can", Litter::Type::EmptyCan },
-            { "rubbish", Litter::Type::Rubbish },
-            { "burger_box", Litter::Type::BurgerBox },
-            { "empty_cup", Litter::Type::EmptyCup },
-            { "empty_box", Litter::Type::EmptyBox },
-            { "empty_bottle", Litter::Type::EmptyBottle },
-            { "empty_bowl_red", Litter::Type::EmptyBowlRed },
-            { "empty_drink_carton", Litter::Type::EmptyDrinkCarton },
-            { "empty_juice_cup", Litter::Type::EmptyJuiceCup },
-            { "empty_bowl_blue", Litter::Type::EmptyBowlBlue },
-        });
+    static const EnumMap<Litter::Type> LitterTypeMap({
+        { "vomit", Litter::Type::Vomit },
+        { "vomit_alt", Litter::Type::VomitAlt },
+        { "empty_can", Litter::Type::EmptyCan },
+        { "rubbish", Litter::Type::Rubbish },
+        { "burger_box", Litter::Type::BurgerBox },
+        { "empty_cup", Litter::Type::EmptyCup },
+        { "empty_box", Litter::Type::EmptyBox },
+        { "empty_bottle", Litter::Type::EmptyBottle },
+        { "empty_bowl_red", Litter::Type::EmptyBowlRed },
+        { "empty_drink_carton", Litter::Type::EmptyDrinkCarton },
+        { "empty_juice_cup", Litter::Type::EmptyJuiceCup },
+        { "empty_bowl_blue", Litter::Type::EmptyBowlBlue },
+    });
 
-    ScLitter::ScLitter(EntityId Id)
-        : ScEntity(Id)
+    class ScEntity;
+    extern ScEntity gScEntity;
+
+    void ScLitter::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("litterType", &ScLitter::litterType_get, &ScLitter::litterType_set),
+            JS_CGETSET_DEF("creationTick", &ScLitter::creationTick_get, nullptr)
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScLitter::Register(duk_context* ctx)
+    Litter* ScLitter::GetLitter(JSValue thisVal)
     {
-        dukglue_set_base_class<ScEntity, ScLitter>(ctx);
-        dukglue_register_property(ctx, &ScLitter::litterType_get, &ScLitter::litterType_set, "litterType");
-        dukglue_register_property(ctx, &ScLitter::creationTick_get, nullptr, "creationTick");
+        auto id = GetEntityId(thisVal);
+        return OpenRCT2::GetEntity<Litter>(id);
     }
 
-    Litter* ScLitter::GetLitter() const
+    JSValue ScLitter::litterType_get(JSContext* ctx, JSValue thisVal)
     {
-        return OpenRCT2::GetEntity<Litter>(_id);
-    }
-
-    std::string ScLitter::litterType_get() const
-    {
-        auto* litter = GetLitter();
+        auto* litter = GetLitter(thisVal);
         if (litter != nullptr)
         {
             auto it = LitterTypeMap.find(litter->SubType);
             if (it != LitterTypeMap.end())
             {
-                return std::string{ it->first };
+                return JS_NewString(ctx, it->first.data());
             }
         }
-        return {};
+        return JS_UNDEFINED;
     }
 
-    void ScLitter::litterType_set(const std::string& litterType)
+    JSValue ScLitter::litterType_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
+        JS_UNPACK_STR(litterType, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto it = LitterTypeMap.find(litterType);
-        if (it == LitterTypeMap.end())
-            return;
-        auto* litter = GetLitter();
-        litter->SubType = it->second;
-        litter->Invalidate();
+        if (it != LitterTypeMap.end())
+        {
+            auto* litter = GetLitter(thisVal);
+            litter->SubType = it->second;
+            litter->Invalidate();
+        }
+        return JS_UNDEFINED;
     }
 
-    uint32_t ScLitter::creationTick_get() const
+    JSValue ScLitter::creationTick_get(JSContext* ctx, JSValue thisVal)
     {
-        auto* litter = GetLitter();
-        if (litter == nullptr)
-            return 0;
-        return litter->creationTick;
+        auto* litter = GetLitter(thisVal);
+        return JS_NewUint32(ctx, litter == nullptr ? 0 : litter->creationTick);
     }
-
 } // namespace OpenRCT2::Scripting
 
 #endif

--- a/src/openrct2/scripting/bindings/entity/ScLitter.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScLitter.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "ScEntity.hpp"
 
@@ -17,22 +17,19 @@ struct Litter;
 
 namespace OpenRCT2::Scripting
 {
-    class ScLitter : public ScEntity
+    class ScLitter final : public ScEntity
     {
     public:
-        ScLitter(EntityId Id);
-
-        static void Register(duk_context* ctx);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
     private:
-        Litter* GetLitter() const;
+        static Litter* GetLitter(JSValue thisVal);
 
-        std::string litterType_get() const;
-        void litterType_set(const std::string& litterType);
+        static JSValue litterType_get(JSContext* ctx, JSValue thisVal);
+        static JSValue litterType_set(JSContext* ctx, JSValue thisVal, JSValue value);
 
-        uint32_t creationTick_get() const;
+        static JSValue creationTick_get(JSContext* ctx, JSValue thisVal);
     };
-
 } // namespace OpenRCT2::Scripting
 
 #endif

--- a/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
@@ -15,9 +15,6 @@
 
 namespace OpenRCT2::Scripting
 {
-    class ScEntity;
-    extern ScEntity gScEntity;
-
     void ScMoneyEffect::AddFuncs(JSContext* ctx, JSValue obj)
     {
         static constexpr JSCFunctionListEntry funcs[] = {

--- a/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "ScMoneyEffect.hpp"
 
@@ -15,41 +15,39 @@
 
 namespace OpenRCT2::Scripting
 {
-    ScMoneyEffect::ScMoneyEffect(EntityId Id)
-        : ScEntity(Id)
+    class ScEntity;
+    extern ScEntity gScEntity;
+
+    void ScMoneyEffect::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("value", &ScMoneyEffect::value_get, &ScMoneyEffect::value_set)
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScMoneyEffect::Register(duk_context* ctx)
+    MoneyEffect* ScMoneyEffect::GetMoneyEffect(JSValue thisVal)
     {
-        dukglue_set_base_class<ScEntity, ScMoneyEffect>(ctx);
-        dukglue_register_property(ctx, &ScMoneyEffect::value_get, &ScMoneyEffect::value_set, "value");
+        auto id = GetEntityId(thisVal);
+        return OpenRCT2::GetEntity<MoneyEffect>(id);
     }
 
-    MoneyEffect* ScMoneyEffect::GetMoneyEffect() const
+    JSValue ScMoneyEffect::value_get(JSContext* ctx, JSValue thisVal)
     {
-        return OpenRCT2::GetEntity<MoneyEffect>(_id);
+        auto moneyEffect = GetMoneyEffect(thisVal);
+        return JS_NewUint32(ctx, moneyEffect == nullptr ? 0 : moneyEffect->Value);
     }
 
-    money64 ScMoneyEffect::value_get() const
+    JSValue ScMoneyEffect::value_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        auto moneyEffect = GetMoneyEffect();
-        if (moneyEffect != nullptr)
-        {
-            return moneyEffect->Value;
-        }
-        return 0;
-    }
-
-    void ScMoneyEffect::value_set(money64 value)
-    {
-        auto moneyEffect = GetMoneyEffect();
+        JS_UNPACK_INT64(value, ctx, jsValue); // TODO: int64 or money64?
+        auto moneyEffect = GetMoneyEffect(thisVal);
         if (moneyEffect != nullptr)
         {
             moneyEffect->SetValue(value);
         }
+        return JS_UNDEFINED;
     }
-
 } // namespace OpenRCT2::Scripting
 
 #endif

--- a/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
@@ -41,6 +41,7 @@ namespace OpenRCT2::Scripting
     JSValue ScMoneyEffect::value_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
         JS_UNPACK_INT64(value, ctx, jsValue); // TODO: int64 or money64?
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
         auto moneyEffect = GetMoneyEffect(thisVal);
         if (moneyEffect != nullptr)
         {

--- a/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
@@ -37,7 +37,7 @@ namespace OpenRCT2::Scripting
 
     JSValue ScMoneyEffect::value_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        JS_UNPACK_INT64(value, ctx, jsValue); // TODO: int64 or money64?
+        JS_UNPACK_MONEY64(value, ctx, jsValue);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
         auto moneyEffect = GetMoneyEffect(thisVal);
         if (moneyEffect != nullptr)

--- a/src/openrct2/scripting/bindings/entity/ScMoneyEffect.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScMoneyEffect.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "ScEntity.hpp"
 
@@ -17,20 +17,16 @@ struct MoneyEffect;
 
 namespace OpenRCT2::Scripting
 {
-
-    class ScMoneyEffect : public ScEntity
+    class ScMoneyEffect final : public ScEntity
     {
     public:
-        ScMoneyEffect(EntityId Id);
-
-        static void Register(duk_context* ctx);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
     private:
-        MoneyEffect* GetMoneyEffect() const;
+        static MoneyEffect* GetMoneyEffect(JSValue thisVal);
 
-        money64 value_get() const;
-        void value_set(money64);
+        static JSValue value_get(JSContext* ctx, JSValue thisVal);
+        static JSValue value_set(JSContext* ctx, JSValue thisVal, JSValue value);
     };
-
 } // namespace OpenRCT2::Scripting
 #endif

--- a/src/openrct2/scripting/bindings/entity/ScParticle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScParticle.cpp
@@ -156,7 +156,7 @@ namespace OpenRCT2::Scripting
 
     JSValue ScCrashedVehicleParticle::Launch(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_OBJECT(obj, ctx, argv[1]); // todo this can go out of bounds?
+        JS_UNPACK_OBJECT(obj, ctx, argv[0]);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
         auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)

--- a/src/openrct2/scripting/bindings/entity/ScParticle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScParticle.cpp
@@ -9,221 +9,240 @@
 
 #include "ScParticle.hpp"
 
+#include "../../../core/EnumMap.hpp"
 #include "../ride/ScRide.hpp"
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
 namespace OpenRCT2::Scripting
 {
-    static const DukEnumMap<uint8_t> CrashParticleTypeMap(
-        {
-            { "corner", 0 },
-            { "rod", 1 },
-            { "wheel", 2 },
-            { "panel", 3 },
-            { "seat", 4 },
-        });
+    static const EnumMap<uint8_t> CrashParticleTypeMap({
+        { "corner", 0 },
+        { "rod", 1 },
+        { "wheel", 2 },
+        { "panel", 3 },
+        { "seat", 4 },
+    });
 
-    ScCrashedVehicleParticle::ScCrashedVehicleParticle(EntityId id)
-        : ScEntity(id)
+    void ScCrashedVehicleParticle::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF(
+                "acceleration", &ScCrashedVehicleParticle::acceleration_get, &ScCrashedVehicleParticle::acceleration_set),
+            JS_CGETSET_DEF("velocity", &ScCrashedVehicleParticle::velocity_get, &ScCrashedVehicleParticle::velocity_set),
+            JS_CGETSET_DEF("colours", &ScCrashedVehicleParticle::colours_get, &ScCrashedVehicleParticle::colours_set),
+            JS_CGETSET_DEF("timeToLive", &ScCrashedVehicleParticle::timeToLive_get, &ScCrashedVehicleParticle::timeToLive_set),
+            JS_CGETSET_DEF(
+                "crashParticleType", &ScCrashedVehicleParticle::crashedSpriteBase_get,
+                &ScCrashedVehicleParticle::crashedSpriteBase_set),
+            JS_CGETSET_DEF("frame", &ScCrashedVehicleParticle::frame_get, &ScCrashedVehicleParticle::frame_set),
+            JS_CFUNC_DEF("launch", 1, &ScCrashedVehicleParticle::Launch),
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScCrashedVehicleParticle::Register(duk_context* ctx)
+    VehicleCrashParticle* ScCrashedVehicleParticle::GetCrashedVehicleParticle(JSValue thisVal)
     {
-        dukglue_set_base_class<ScEntity, ScCrashedVehicleParticle>(ctx);
-        dukglue_register_property(
-            ctx, &ScCrashedVehicleParticle::acceleration_get, &ScCrashedVehicleParticle::acceleration_set, "acceleration");
-        dukglue_register_property(
-            ctx, &ScCrashedVehicleParticle::velocity_get, &ScCrashedVehicleParticle::velocity_set, "velocity");
-        dukglue_register_property(
-            ctx, &ScCrashedVehicleParticle::colours_get, &ScCrashedVehicleParticle::colours_set, "colours");
-        dukglue_register_property(
-            ctx, &ScCrashedVehicleParticle::timeToLive_get, &ScCrashedVehicleParticle::timeToLive_set, "timeToLive");
-        dukglue_register_property(
-            ctx, &ScCrashedVehicleParticle::crashedSpriteBase_get, &ScCrashedVehicleParticle::crashedSpriteBase_set,
-            "crashParticleType");
-        dukglue_register_property(ctx, &ScCrashedVehicleParticle::frame_get, &ScCrashedVehicleParticle::frame_set, "frame");
-        dukglue_register_method(ctx, &ScCrashedVehicleParticle::Launch, "launch");
+        auto id = GetEntityId(thisVal);
+        return OpenRCT2::GetEntity<VehicleCrashParticle>(id);
     }
 
-    VehicleCrashParticle* ScCrashedVehicleParticle::GetCrashedVehicleParticle() const
+    JSValue ScCrashedVehicleParticle::frame_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        return OpenRCT2::GetEntity<VehicleCrashParticle>(_id);
-    }
-
-    void ScCrashedVehicleParticle::frame_set(uint8_t value)
-    {
-        auto entity = GetCrashedVehicleParticle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
             entity->frame = std::clamp<uint16_t>(value, 0, kCrashedVehicleParticleNumberSprites - 1)
                 * kCrashedVehicleParticleFrameToSprite;
             entity->Invalidate();
         }
+        return JS_UNDEFINED;
     }
-    uint8_t ScCrashedVehicleParticle::frame_get() const
+    JSValue ScCrashedVehicleParticle::frame_get(JSContext* ctx, JSValue thisVal)
     {
-        auto entity = GetCrashedVehicleParticle();
-        if (entity != nullptr)
-        {
-            return entity->frame / kCrashedVehicleParticleFrameToSprite;
-        }
-        return 0;
+        auto entity = GetCrashedVehicleParticle(thisVal);
+        auto frame = (entity != nullptr) ? entity->frame / kCrashedVehicleParticleFrameToSprite : 0;
+        return JS_NewUint32(ctx, frame);
     }
 
-    void ScCrashedVehicleParticle::crashedSpriteBase_set(const std::string& value)
+    JSValue ScCrashedVehicleParticle::crashedSpriteBase_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        auto entity = GetCrashedVehicleParticle();
+        JS_UNPACK_STR(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
             entity->crashed_sprite_base = CrashParticleTypeMap[value];
             entity->Invalidate();
         }
+        return JS_UNDEFINED;
     }
-    std::string ScCrashedVehicleParticle::crashedSpriteBase_get() const
+    JSValue ScCrashedVehicleParticle::crashedSpriteBase_get(JSContext* ctx, JSValue thisVal)
     {
-        auto entity = GetCrashedVehicleParticle();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
-            return std::string(CrashParticleTypeMap[entity->crashed_sprite_base]);
+            return JSFromStdString(ctx, CrashParticleTypeMap[entity->crashed_sprite_base]);
         }
-        return {};
+        return JS_UNDEFINED;
     }
 
-    void ScCrashedVehicleParticle::timeToLive_set(uint16_t value)
+    JSValue ScCrashedVehicleParticle::timeToLive_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        auto entity = GetCrashedVehicleParticle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
             entity->time_to_live = value;
         }
+        return JS_UNDEFINED;
     }
-    uint16_t ScCrashedVehicleParticle::timeToLive_get() const
+    JSValue ScCrashedVehicleParticle::timeToLive_get(JSContext* ctx, JSValue thisVal)
     {
-        auto entity = GetCrashedVehicleParticle();
-        if (entity != nullptr)
-        {
-            return entity->time_to_live;
-        }
-        return 0;
+        auto entity = GetCrashedVehicleParticle(thisVal);
+        return JS_NewUint32(ctx, entity == nullptr ? 0 : entity->time_to_live);
     }
 
-    void ScCrashedVehicleParticle::velocity_set(const DukValue& value)
+    JSValue ScCrashedVehicleParticle::velocity_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        auto entity = GetCrashedVehicleParticle();
+        JS_UNPACK_OBJECT(obj, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
-            auto velocity = FromDuk<CoordsXYZ>(value);
+            auto velocity = JSToCoordXYZ(ctx, obj);
             entity->velocity_x = velocity.x;
             entity->velocity_y = velocity.y;
             entity->velocity_z = velocity.z;
         }
+        return JS_UNDEFINED;
     }
-    DukValue ScCrashedVehicleParticle::velocity_get() const
+    JSValue ScCrashedVehicleParticle::velocity_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-        auto entity = GetCrashedVehicleParticle();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
-            return ToDuk(ctx, CoordsXYZ(entity->velocity_x, entity->velocity_y, entity->velocity_z));
+            return ToJSValue(ctx, CoordsXYZ(entity->velocity_x, entity->velocity_y, entity->velocity_z));
         }
-        return {};
+        return JS_UNDEFINED;
     }
 
-    void ScCrashedVehicleParticle::acceleration_set(const DukValue& value)
+    JSValue ScCrashedVehicleParticle::acceleration_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        auto entity = GetCrashedVehicleParticle();
+        JS_UNPACK_OBJECT(obj, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
-            auto acceleration = FromDuk<CoordsXYZ>(value);
+            auto acceleration = JSToCoordXYZ(ctx, obj);
             entity->acceleration_x = acceleration.x;
             entity->acceleration_y = acceleration.y;
             entity->acceleration_z = acceleration.z;
         }
+        return JS_UNDEFINED;
     }
-    DukValue ScCrashedVehicleParticle::acceleration_get() const
+    JSValue ScCrashedVehicleParticle::acceleration_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-        auto entity = GetCrashedVehicleParticle();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
-            return ToDuk(ctx, CoordsXYZ(entity->acceleration_x, entity->acceleration_y, entity->acceleration_z));
+            return ToJSValue(ctx, CoordsXYZ(entity->acceleration_x, entity->acceleration_y, entity->acceleration_z));
         }
-        return {};
+        return JS_UNDEFINED;
     }
 
-    void ScCrashedVehicleParticle::Launch(const DukValue& value)
+    JSValue ScCrashedVehicleParticle::Launch(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        auto entity = GetCrashedVehicleParticle();
+        JS_UNPACK_OBJECT(obj, ctx, argv[1]); // todo this can go out of bounds?
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
             entity->SetSpriteData();
             entity->Launch();
 
-            if (value.type() == DukValue::Type::UNDEFINED)
-                return;
+            if (JS_IsUndefined(obj))
+                return JS_UNDEFINED;
 
-            if (value["colours"].type() == DukValue::Type::OBJECT)
+            auto colours = JS_GetPropertyStr(ctx, obj, "colours");
+            auto acceleration = JS_GetPropertyStr(ctx, obj, "acceleration");
+            auto velocity = JS_GetPropertyStr(ctx, obj, "velocity");
+            auto timeToLive = JS_GetPropertyStr(ctx, obj, "timeToLive");
+            auto frame = JS_GetPropertyStr(ctx, obj, "frame");
+            auto crashParticleType = JS_GetPropertyStr(ctx, obj, "crashParticleType");
+
+            if (JS_IsObject(colours))
             {
-                auto coloursInt = FromDuk<VehicleColour>(value["colours"]);
-                entity->colour[0] = coloursInt.Body;
-                entity->colour[1] = coloursInt.Trim;
+                entity->colour[0] = JSToUint(ctx, colours, "body");
+                entity->colour[1] = JSToUint(ctx, colours, "trim");
             }
-            if (value["acceleration"].type() == DukValue::Type::OBJECT)
+            if (JS_IsObject(acceleration))
             {
-                auto accelerationXYZ = FromDuk<CoordsXYZ>(value["acceleration"]);
+                auto accelerationXYZ = JSToCoordXYZ(ctx, acceleration);
                 entity->acceleration_x = accelerationXYZ.x;
                 entity->acceleration_y = accelerationXYZ.y;
                 entity->acceleration_z = accelerationXYZ.z;
             }
-            if (value["velocity"].type() == DukValue::Type::OBJECT)
+            if (JS_IsObject(velocity))
             {
-                auto velocityXYZ = FromDuk<CoordsXYZ>(value["velocity"]);
+                auto velocityXYZ = JSToCoordXYZ(ctx, velocity);
                 entity->velocity_x = velocityXYZ.x;
                 entity->velocity_y = velocityXYZ.y;
                 entity->velocity_z = velocityXYZ.z;
             }
-            if (value["timeToLive"].type() == DukValue::Type::NUMBER)
+            if (JS_IsNumber(timeToLive))
             {
-                entity->time_to_live = value["timeToLive"].as_uint();
+                entity->time_to_live = JSToUint(ctx, timeToLive);
             }
-            if (value["frame"].type() == DukValue::Type::NUMBER)
+            if (JS_IsNumber(frame))
             {
-                entity->frame = std::clamp<uint16_t>(value["frame"].as_uint(), 0, kCrashedVehicleParticleNumberSprites - 1)
+                entity->frame = std::clamp<uint16_t>(JSToUint(ctx, frame), 0, kCrashedVehicleParticleNumberSprites - 1)
                     * kCrashedVehicleParticleFrameToSprite;
             }
-            if (value["crashParticleType"].type() == DukValue::Type::STRING)
+            if (JS_IsString(crashParticleType))
             {
-                entity->crashed_sprite_base = CrashParticleTypeMap[value["crashParticleType"].as_string()];
+                auto key = JSToStdString(ctx, crashParticleType);
+                entity->crashed_sprite_base = CrashParticleTypeMap[key];
             }
             entity->Invalidate();
+
+            JS_FreeValue(ctx, colours);
+            JS_FreeValue(ctx, acceleration);
+            JS_FreeValue(ctx, velocity);
+            JS_FreeValue(ctx, timeToLive);
+            JS_FreeValue(ctx, frame);
+            JS_FreeValue(ctx, crashParticleType);
         }
+        return JS_UNDEFINED;
     }
 
-    DukValue ScCrashedVehicleParticle::colours_get() const
+    JSValue ScCrashedVehicleParticle::colours_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-        auto entity = GetCrashedVehicleParticle();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
-            DukObject dukColour(ctx);
-            dukColour.Set("body", entity->colour[0]);
-            dukColour.Set("trim", entity->colour[1]);
-            return dukColour.Take();
+            JSValue obj = JS_NewObject(ctx);
+            JS_SetPropertyStr(ctx, obj, "body", JS_NewInt32(ctx, entity->colour[0]));
+            JS_SetPropertyStr(ctx, obj, "trim", JS_NewInt32(ctx, entity->colour[1]));
+            return obj;
         }
-        return ToDuk(ctx, nullptr);
+        return JS_NULL;
     }
-    void ScCrashedVehicleParticle::colours_set(const DukValue& value)
+    JSValue ScCrashedVehicleParticle::colours_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        auto entity = GetCrashedVehicleParticle();
+        JS_UNPACK_OBJECT(obj, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto entity = GetCrashedVehicleParticle(thisVal);
         if (entity != nullptr)
         {
-            auto colours = FromDuk<VehicleColour>(value);
-            entity->colour[0] = colours.Body;
-            entity->colour[1] = colours.Trim;
+            entity->colour[0] = JSToUint(ctx, obj, "body");
+            entity->colour[1] = JSToUint(ctx, obj, "trim");
             entity->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 }; // namespace OpenRCT2::Scripting
 

--- a/src/openrct2/scripting/bindings/entity/ScParticle.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScParticle.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "../../../entity/Particle.h"
     #include "../../../world/Location.hpp"
@@ -19,35 +19,33 @@
 
 namespace OpenRCT2::Scripting
 {
-    class ScCrashedVehicleParticle : public ScEntity
+    class ScCrashedVehicleParticle final : public ScEntity
     {
     public:
-        ScCrashedVehicleParticle(EntityId id);
-
-        static void Register(duk_context* ctx);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
     private:
-        VehicleCrashParticle* GetCrashedVehicleParticle() const;
+        static VehicleCrashParticle* GetCrashedVehicleParticle(JSValue thisVal);
 
-        DukValue colours_get() const;
-        void colours_set(const DukValue& value);
+        static JSValue colours_get(JSContext* ctx, JSValue thisVal);
+        static JSValue colours_set(JSContext* ctx, JSValue thisVal, JSValue value);
 
-        DukValue acceleration_get() const;
-        void acceleration_set(const DukValue& value);
+        static JSValue acceleration_get(JSContext* ctx, JSValue thisVal);
+        static JSValue acceleration_set(JSContext* ctx, JSValue thisVal, JSValue value);
 
-        DukValue velocity_get() const;
-        void velocity_set(const DukValue& value);
+        static JSValue velocity_get(JSContext* ctx, JSValue thisVal);
+        static JSValue velocity_set(JSContext* ctx, JSValue thisVal, JSValue value);
 
-        uint8_t frame_get() const;
-        void frame_set(uint8_t value);
+        static JSValue frame_get(JSContext* ctx, JSValue thisVal);
+        static JSValue frame_set(JSContext* ctx, JSValue thisVal, JSValue value);
 
-        void crashedSpriteBase_set(const std::string& value);
-        std::string crashedSpriteBase_get() const;
+        static JSValue crashedSpriteBase_get(JSContext* ctx, JSValue thisVal);
+        static JSValue crashedSpriteBase_set(JSContext* ctx, JSValue thisVal, JSValue value);
 
-        void timeToLive_set(uint16_t value);
-        uint16_t timeToLive_get() const;
+        static JSValue timeToLive_get(JSContext* ctx, JSValue thisVal);
+        static JSValue timeToLive_set(JSContext* ctx, JSValue thisVal, JSValue value);
 
-        void Launch(const DukValue& value);
+        static JSValue Launch(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
     };
 }; // namespace OpenRCT2::Scripting
 

--- a/src/openrct2/scripting/bindings/entity/ScPeep.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScPeep.hpp
@@ -61,8 +61,8 @@ namespace OpenRCT2::Scripting
                 JS_CGETSET_DEF("direction", &ScPeep::direction_get, &ScPeep::direction_set),
                 JS_CGETSET_DEF("energy", &ScPeep::energy_get, &ScPeep::energy_set),
                 JS_CGETSET_DEF("energyTarget", &ScPeep::energyTarget_get, &ScPeep::energyTarget_set),
-                JS_CFUNC_DEF("getFlag", 0, &ScPeep::getFlag),
-                JS_CFUNC_DEF("setFlag", 0, &ScPeep::setFlag),
+                JS_CFUNC_DEF("getFlag", 1, &ScPeep::getFlag),
+                JS_CFUNC_DEF("setFlag", 2, &ScPeep::setFlag),
             };
             JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
         }

--- a/src/openrct2/scripting/bindings/entity/ScPeep.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScPeep.hpp
@@ -97,7 +97,7 @@ namespace OpenRCT2::Scripting
 
         static JSValue getFlag(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
         {
-            JS_UNPACK_STR(key, ctx, argv[1]); // todo this can go out of bounds?
+            JS_UNPACK_STR(key, ctx, argv[0]);
             auto peep = GetPeep(thisVal);
             if (peep != nullptr)
             {
@@ -109,8 +109,8 @@ namespace OpenRCT2::Scripting
 
         static JSValue setFlag(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
         {
-            JS_UNPACK_STR(key, ctx, argv[1]);    // todo this can go out of bounds?
-            JS_UNPACK_BOOL(value, ctx, argv[2]); // todo this can go out of bounds?
+            JS_UNPACK_STR(key, ctx, argv[0]);
+            JS_UNPACK_BOOL(value, ctx, argv[1]);
             JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
             auto peep = GetPeep(thisVal);
             if (peep != nullptr)

--- a/src/openrct2/scripting/bindings/entity/ScPeep.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScPeep.hpp
@@ -9,105 +9,110 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
+    #include "../../../core/EnumMap.hpp"
     #include "ScEntity.hpp"
 
 namespace OpenRCT2::Scripting
 {
-    static const DukEnumMap<uint32_t> PeepFlagMap(
-        {
-            { "leavingPark", PEEP_FLAGS_LEAVING_PARK },
-            { "slowWalk", PEEP_FLAGS_SLOW_WALK },
-            { "tracking", PEEP_FLAGS_TRACKING },
-            { "waving", PEEP_FLAGS_WAVING },
-            { "hasPaidForParkEntry", PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY },
-            { "photo", PEEP_FLAGS_PHOTO },
-            { "painting", PEEP_FLAGS_PAINTING },
-            { "wow", PEEP_FLAGS_WOW },
-            { "litter", PEEP_FLAGS_LITTER },
-            { "lost", PEEP_FLAGS_LOST },
-            { "hunger", PEEP_FLAGS_HUNGER },
-            { "toilet", PEEP_FLAGS_TOILET },
-            { "crowded", PEEP_FLAGS_CROWDED },
-            { "happiness", PEEP_FLAGS_HAPPINESS },
-            { "nausea", PEEP_FLAGS_NAUSEA },
-            { "purple", PEEP_FLAGS_PURPLE },
-            { "pizza", PEEP_FLAGS_PIZZA },
-            { "explode", PEEP_FLAGS_EXPLODE },
-            { "rideShouldBeMarkedAsFavourite", PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE },
-            { "parkEntranceChosen", PEEP_FLAGS_PARK_ENTRANCE_CHOSEN },
-            { "contagious", PEEP_FLAGS_CONTAGIOUS },
-            { "joy", PEEP_FLAGS_JOY },
-            { "angry", PEEP_FLAGS_ANGRY },
-            { "iceCream", PEEP_FLAGS_ICE_CREAM },
-            { "hereWeAre", PEEP_FLAGS_HERE_WE_ARE },
-            { "positionFrozen", PEEP_FLAGS_POSITION_FROZEN },
-            { "animationFrozen", PEEP_FLAGS_ANIMATION_FROZEN },
-        });
+    static const EnumMap<uint32_t> PeepFlagMap({
+        { "leavingPark", PEEP_FLAGS_LEAVING_PARK },
+        { "slowWalk", PEEP_FLAGS_SLOW_WALK },
+        { "tracking", PEEP_FLAGS_TRACKING },
+        { "waving", PEEP_FLAGS_WAVING },
+        { "hasPaidForParkEntry", PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY },
+        { "photo", PEEP_FLAGS_PHOTO },
+        { "painting", PEEP_FLAGS_PAINTING },
+        { "wow", PEEP_FLAGS_WOW },
+        { "litter", PEEP_FLAGS_LITTER },
+        { "lost", PEEP_FLAGS_LOST },
+        { "hunger", PEEP_FLAGS_HUNGER },
+        { "toilet", PEEP_FLAGS_TOILET },
+        { "crowded", PEEP_FLAGS_CROWDED },
+        { "happiness", PEEP_FLAGS_HAPPINESS },
+        { "nausea", PEEP_FLAGS_NAUSEA },
+        { "purple", PEEP_FLAGS_PURPLE },
+        { "pizza", PEEP_FLAGS_PIZZA },
+        { "explode", PEEP_FLAGS_EXPLODE },
+        { "rideShouldBeMarkedAsFavourite", PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE },
+        { "parkEntranceChosen", PEEP_FLAGS_PARK_ENTRANCE_CHOSEN },
+        { "contagious", PEEP_FLAGS_CONTAGIOUS },
+        { "joy", PEEP_FLAGS_JOY },
+        { "angry", PEEP_FLAGS_ANGRY },
+        { "iceCream", PEEP_FLAGS_ICE_CREAM },
+        { "hereWeAre", PEEP_FLAGS_HERE_WE_ARE },
+        { "positionFrozen", PEEP_FLAGS_POSITION_FROZEN },
+        { "animationFrozen", PEEP_FLAGS_ANIMATION_FROZEN },
+    });
+
+    class ScEntity;
+    extern ScEntity gScEntity;
 
     class ScPeep : public ScEntity
     {
     public:
-        ScPeep(EntityId id)
-            : ScEntity(id)
+        static void AddFuncs(JSContext* ctx, JSValue obj)
         {
-        }
-
-        static void Register(duk_context* ctx)
-        {
-            dukglue_set_base_class<ScEntity, ScPeep>(ctx);
-            dukglue_register_property(ctx, &ScPeep::peepType_get, nullptr, "peepType");
-            dukglue_register_property(ctx, &ScPeep::name_get, &ScPeep::name_set, "name");
-            dukglue_register_property(ctx, &ScPeep::destination_get, &ScPeep::destination_set, "destination");
-            dukglue_register_property(ctx, &ScPeep::direction_get, &ScPeep::direction_set, "direction");
-            dukglue_register_property(ctx, &ScPeep::energy_get, &ScPeep::energy_set, "energy");
-            dukglue_register_property(ctx, &ScPeep::energyTarget_get, &ScPeep::energyTarget_set, "energyTarget");
-            dukglue_register_method(ctx, &ScPeep::getFlag, "getFlag");
-            dukglue_register_method(ctx, &ScPeep::setFlag, "setFlag");
+            static constexpr JSCFunctionListEntry funcs[] = {
+                JS_CGETSET_DEF("peepType", &ScPeep::peepType_get, nullptr),
+                JS_CGETSET_DEF("name", &ScPeep::name_get, &ScPeep::name_set),
+                JS_CGETSET_DEF("destination", &ScPeep::destination_get, &ScPeep::destination_set),
+                JS_CGETSET_DEF("direction", &ScPeep::direction_get, &ScPeep::direction_set),
+                JS_CGETSET_DEF("energy", &ScPeep::energy_get, &ScPeep::energy_set),
+                JS_CGETSET_DEF("energyTarget", &ScPeep::energyTarget_get, &ScPeep::energyTarget_set),
+                JS_CFUNC_DEF("getFlag", 0, &ScPeep::getFlag),
+                JS_CFUNC_DEF("setFlag", 0, &ScPeep::setFlag),
+            };
+            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
         }
 
     private:
-        std::string peepType_get() const
+        static JSValue peepType_get(JSContext* ctx, JSValue thisVal)
         {
-            auto peep = GetPeep();
+            auto peep = GetPeep(thisVal);
             if (peep != nullptr)
             {
-                return peep->Is<Staff>() ? "staff" : "guest";
+                return JS_NewString(ctx, peep->Is<Staff>() ? "staff" : "guest");
             }
-            return {};
+            return JS_UNDEFINED;
         }
 
-        std::string name_get() const
+        static JSValue name_get(JSContext* ctx, JSValue thisVal)
         {
-            auto peep = GetPeep();
-            return peep != nullptr ? peep->GetName() : std::string();
+            auto peep = GetPeep(thisVal);
+            return JSFromStdString(ctx, peep != nullptr ? peep->GetName() : std::string());
         }
-        void name_set(const std::string& value)
+        static JSValue name_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
         {
-            ThrowIfGameStateNotMutable();
-            auto peep = GetPeep();
+            JS_UNPACK_STR(value, ctx, jsValue);
+            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+            auto peep = GetPeep(thisVal);
             if (peep != nullptr)
             {
                 peep->SetName(value);
             }
+            return JS_UNDEFINED;
         }
 
-        bool getFlag(const std::string& key) const
+        static JSValue getFlag(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
         {
-            auto peep = GetPeep();
+            JS_UNPACK_STR(key, ctx, argv[1]); // todo this can go out of bounds?
+            auto peep = GetPeep(thisVal);
             if (peep != nullptr)
             {
                 auto mask = PeepFlagMap[key];
-                return (peep->PeepFlags & mask) != 0;
+                return JS_NewBool(ctx, (peep->PeepFlags & mask) != 0);
             }
-            return false;
+            return JS_NewBool(ctx, false);
         }
 
-        void setFlag(const std::string& key, bool value)
+        static JSValue setFlag(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
         {
-            ThrowIfGameStateNotMutable();
-            auto peep = GetPeep();
+            JS_UNPACK_STR(key, ctx, argv[1]);    // todo this can go out of bounds?
+            JS_UNPACK_BOOL(value, ctx, argv[2]); // todo this can go out of bounds?
+            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+            auto peep = GetPeep(thisVal);
             if (peep != nullptr)
             {
                 auto mask = PeepFlagMap[key];
@@ -117,86 +122,95 @@ namespace OpenRCT2::Scripting
                     peep->PeepFlags &= ~mask;
                 peep->Invalidate();
             }
+            return JS_UNDEFINED;
         }
 
-        DukValue destination_get() const
+        static JSValue destination_get(JSContext* ctx, JSValue thisVal)
         {
-            auto ctx = GetContext()->GetScriptEngine().GetContext();
-            auto peep = GetPeep();
+            auto peep = GetPeep(thisVal);
             if (peep != nullptr)
             {
-                return ToDuk(ctx, peep->GetDestination());
+                return ToJSValue(ctx, peep->GetDestination());
             }
-            return ToDuk(ctx, nullptr);
+            return JS_NULL;
         }
 
-        void destination_set(const DukValue& value)
+        static JSValue destination_set(JSContext* ctx, JSValue thisVal, JSValue jsValue) //(const DukValue& value)
         {
-            ThrowIfGameStateNotMutable();
-            auto peep = GetPeep();
+            JS_UNPACK_OBJECT(value, ctx, jsValue);
+            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+            auto peep = GetPeep(thisVal);
             if (peep != nullptr)
             {
-                auto pos = FromDuk<CoordsXY>(value);
+                auto pos = JSToCoordXY(ctx, value);
                 peep->SetDestination(pos);
                 peep->Invalidate();
             }
+            return JS_UNDEFINED;
         }
 
-        uint8_t direction_get() const
+        static JSValue direction_get(JSContext* ctx, JSValue thisVal)
         {
-            auto peep = GetPeep();
-            return peep != nullptr ? peep->PeepDirection : 0;
+            auto peep = GetPeep(thisVal);
+            return JS_NewUint32(ctx, peep != nullptr ? peep->PeepDirection : 0);
         }
 
-        void direction_set(const uint8_t value)
+        static JSValue direction_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
         {
-            ThrowIfGameStateNotMutable();
-            auto peep = GetPeep();
+            JS_UNPACK_UINT32(value, ctx, jsValue);
+            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+            auto peep = GetPeep(thisVal);
             if (peep != nullptr && value < kNumOrthogonalDirections)
             {
                 peep->PeepDirection = value;
                 peep->Orientation = value << 3;
                 peep->Invalidate();
             }
+            return JS_UNDEFINED;
         }
 
-        uint8_t energy_get() const
+        static JSValue energy_get(JSContext* ctx, JSValue thisVal)
         {
-            auto peep = GetPeep();
-            return peep != nullptr ? peep->Energy : 0;
+            auto peep = GetPeep(thisVal);
+            return JS_NewUint32(ctx, peep != nullptr ? peep->Energy : 0);
         }
-        void energy_set(uint8_t value)
+        static JSValue energy_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
         {
-            ThrowIfGameStateNotMutable();
-            auto peep = GetPeep();
+            JS_UNPACK_UINT32(value, ctx, jsValue);
+            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+            auto peep = GetPeep(thisVal);
             if (peep != nullptr)
             {
-                value = std::clamp(value, kPeepMinEnergy, kPeepMaxEnergy);
+                value = std::clamp(static_cast<uint8_t>(value), kPeepMinEnergy, kPeepMaxEnergy);
                 peep->Energy = value;
                 peep->Invalidate();
             }
+            return JS_UNDEFINED;
         }
 
-        uint8_t energyTarget_get() const
+        static JSValue energyTarget_get(JSContext* ctx, JSValue thisVal)
         {
-            auto peep = GetPeep();
-            return peep != nullptr ? peep->EnergyTarget : 0;
+            auto peep = GetPeep(thisVal);
+            return JS_NewUint32(ctx, peep != nullptr ? peep->EnergyTarget : 0);
         }
-        void energyTarget_set(uint8_t value)
+        static JSValue energyTarget_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
         {
-            ThrowIfGameStateNotMutable();
-            auto peep = GetPeep();
+            JS_UNPACK_UINT32(value, ctx, jsValue);
+            JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+            auto peep = GetPeep(thisVal);
             if (peep != nullptr)
             {
-                value = std::clamp(value, kPeepMinEnergy, kPeepMaxEnergyTarget);
-                peep->EnergyTarget = value;
+                auto target = std::clamp(static_cast<uint8_t>(value), kPeepMinEnergy, kPeepMaxEnergyTarget);
+                peep->EnergyTarget = target;
             }
+            return JS_UNDEFINED;
         }
 
     protected:
-        Peep* GetPeep() const
+        static Peep* GetPeep(JSValue thisVal)
         {
-            return OpenRCT2::GetEntity<Peep>(_id);
+            auto id = GetEntityId(thisVal);
+            return OpenRCT2::GetEntity<Peep>(id);
         }
     };
 

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "ScStaff.hpp"
 
@@ -19,59 +19,58 @@
 
 namespace OpenRCT2::Scripting
 {
-    ScStaff::ScStaff(EntityId Id)
-        : ScPeep(Id)
+    void ScStaff::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("staffType", &ScStaff::staffType_get, &ScStaff::staffType_set),
+            JS_CGETSET_DEF("colour", &ScStaff::colour_get, &ScStaff::colour_set),
+            JS_CGETSET_DEF("availableCostumes", &ScStaff::availableCostumes_get, nullptr),
+            JS_CGETSET_DEF("costume", &ScStaff::costume_get, &ScStaff::costume_set),
+            JS_CGETSET_DEF("patrolArea", &ScStaff::patrolArea_get, nullptr),
+            JS_CGETSET_DEF("orders", &ScStaff::orders_get, &ScStaff::orders_set),
+            JS_CGETSET_DEF("availableAnimations", &ScStaff::availableAnimations_get, nullptr),
+            JS_CGETSET_DEF("animation", &ScStaff::animation_get, &ScStaff::animation_set),
+            JS_CGETSET_DEF("animationOffset", &ScStaff::animationOffset_get, &ScStaff::animationOffset_set),
+            JS_CGETSET_DEF("animationLength", &ScStaff::animationLength_get, nullptr),
+            JS_CFUNC_DEF("getAnimationSpriteIds", 2, &ScStaff::getAnimationSpriteIds),
+            JS_CFUNC_DEF("getCostumeStrings", 0, &ScStaff::getCostumeStrings)
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScStaff::Register(duk_context* ctx)
+    Staff* ScStaff::GetStaff(JSValue thisVal)
     {
-        dukglue_set_base_class<ScPeep, ScStaff>(ctx);
-        dukglue_register_property(ctx, &ScStaff::staffType_get, &ScStaff::staffType_set, "staffType");
-        dukglue_register_property(ctx, &ScStaff::colour_get, &ScStaff::colour_set, "colour");
-        dukglue_register_property(ctx, &ScStaff::availableCostumes_get, nullptr, "availableCostumes");
-        dukglue_register_property(ctx, &ScStaff::costume_get, &ScStaff::costume_set, "costume");
-        dukglue_register_property(ctx, &ScStaff::patrolArea_get, nullptr, "patrolArea");
-        dukglue_register_property(ctx, &ScStaff::orders_get, &ScStaff::orders_set, "orders");
-        dukglue_register_property(ctx, &ScStaff::availableAnimations_get, nullptr, "availableAnimations");
-        dukglue_register_property(ctx, &ScStaff::animation_get, &ScStaff::animation_set, "animation");
-        dukglue_register_property(ctx, &ScStaff::animationOffset_get, &ScStaff::animationOffset_set, "animationOffset");
-        dukglue_register_property(ctx, &ScStaff::animationLength_get, nullptr, "animationLength");
-        dukglue_register_method(ctx, &ScStaff::getAnimationSpriteIds, "getAnimationSpriteIds");
-        dukglue_register_method(ctx, &ScStaff::getCostumeStrings, "getCostumeStrings");
+        auto id = GetEntityId(thisVal);
+        return OpenRCT2::GetEntity<Staff>(id);
     }
 
-    Staff* ScStaff::GetStaff() const
+    JSValue ScStaff::staffType_get(JSContext* ctx, JSValue thisVal)
     {
-        return OpenRCT2::GetEntity<Staff>(_id);
-    }
-
-    std::string ScStaff::staffType_get() const
-    {
-        auto peep = GetStaff();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr)
         {
             switch (peep->AssignedStaffType)
             {
                 case StaffType::Handyman:
-                    return "handyman";
+                    return JS_NewString(ctx, "handyman");
                 case StaffType::Mechanic:
-                    return "mechanic";
+                    return JS_NewString(ctx, "mechanic");
                 case StaffType::Security:
-                    return "security";
+                    return JS_NewString(ctx, "security");
                 case StaffType::Entertainer:
-                    return "entertainer";
+                    return JS_NewString(ctx, "entertainer");
                 case StaffType::Count:
                     break;
             }
         }
-        return {};
+        return JS_UNDEFINED;
     }
 
-    void ScStaff::staffType_set(const std::string& value)
+    JSValue ScStaff::staffType_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        JS_UNPACK_STR(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr)
         {
             if (value == "handyman" && peep->AssignedStaffType != StaffType::Handyman)
@@ -104,24 +103,27 @@ namespace OpenRCT2::Scripting
             peep->AnimationType = peep->NextAnimationType = PeepAnimationType::Walking;
             peep->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScStaff::colour_get() const
+    JSValue ScStaff::colour_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetStaff();
-        return peep != nullptr ? peep->TshirtColour : 0;
+        auto peep = GetStaff(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->TshirtColour : 0);
     }
 
-    void ScStaff::colour_set(uint8_t value)
+    JSValue ScStaff::colour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr)
         {
             peep->TshirtColour = value;
             peep->TrousersColour = value;
             peep->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
     static const std::vector<AnimationGroupResult> costumesByStaffType(StaffType staffType)
@@ -131,39 +133,42 @@ namespace OpenRCT2::Scripting
         return getAnimationGroupsByPeepType(animPeepType);
     }
 
-    std::vector<std::string> ScStaff::availableCostumes_get() const
+    JSValue ScStaff::availableCostumes_get(JSContext* ctx, JSValue thisVal)
     {
-        std::vector<std::string> availableCostumes{};
-        auto peep = GetStaff();
+        JSValue availableCostumes = JS_NewArray(ctx);
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr)
         {
+            auto idx = 0;
             for (auto& costume : costumesByStaffType(peep->AssignedStaffType))
             {
-                availableCostumes.push_back(std::string(costume.scriptName));
+                JS_SetPropertyInt64(ctx, availableCostumes, idx++, JSFromStdString(ctx, costume.scriptName));
             }
         }
         return availableCostumes;
     }
 
-    std::vector<std::string> ScStaff::getCostumeStrings() const
+    JSValue ScStaff::getCostumeStrings(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        auto peep = GetStaff();
+        auto peep = GetStaff(thisVal);
         auto animPeepType = getAnimationPeepType(peep->AssignedStaffType);
 
-        std::vector<std::string> availableCostumes{};
+        JSValue availableCostumes = JS_NewArray(ctx);
+        auto idx = 0;
+
         for (auto& costume : getAvailableCostumeStrings(animPeepType))
         {
-            availableCostumes.push_back(costume.friendlyName);
+            JS_SetPropertyInt64(ctx, availableCostumes, idx++, JSFromStdString(ctx, costume.friendlyName));
         }
         return availableCostumes;
     }
 
-    std::string ScStaff::costume_get() const
+    JSValue ScStaff::costume_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetStaff();
+        auto peep = GetStaff(thisVal);
         if (peep == nullptr)
         {
-            return {};
+            return JS_UNDEFINED;
         }
 
         auto& costumes = costumesByStaffType(peep->AssignedStaffType);
@@ -174,69 +179,78 @@ namespace OpenRCT2::Scripting
 
         if (costume != costumes.end())
         {
-            return std::string(costume->scriptName);
+            return JSFromStdString(ctx, costume->scriptName);
         }
         else
-            return "";
+            return JS_UNDEFINED;
     }
 
-    void ScStaff::costume_set(const DukValue& value)
+    JSValue ScStaff::costume_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
-        ThrowIfGameStateNotMutable();
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
-        auto peep = GetStaff();
+        auto peep = GetStaff(thisVal);
         if (peep == nullptr)
         {
-            return;
+            return JS_UNDEFINED;
         }
 
         auto& costumes = costumesByStaffType(peep->AssignedStaffType);
         auto costume = costumes.end();
 
         // Split by type passed so as to not break old plugins
-        if (value.type() == DukValue::Type::STRING)
+        if (JS_IsString(value))
         {
-            costume = std::find_if(costumes.begin(), costumes.end(), [value](auto& candidate) {
-                return candidate.scriptName == value.as_string();
+            JS_UNPACK_STR(valueString, ctx, value);
+            costume = std::find_if(costumes.begin(), costumes.end(), [valueString](auto& candidate) {
+                return candidate.scriptName == valueString;
             });
         }
-        else if (value.type() == DukValue::Type::NUMBER)
+        else if (JS_IsNumber(value))
         {
-            auto target = RCT12PeepAnimationGroup(value.as_uint() + EnumValue(RCT12PeepAnimationGroup::EntertainerPanda));
+            JS_UNPACK_UINT32(number, ctx, value);
+            auto target = RCT12PeepAnimationGroup(number + EnumValue(RCT12PeepAnimationGroup::EntertainerPanda));
             costume = std::find_if(
                 costumes.begin(), costumes.end(), [target](auto& candidate) { return candidate.legacyPosition == target; });
         }
 
         if (costume == costumes.end())
-            throw DukException() << "Invalid costume for this staff member";
+        {
+            JS_ThrowPlainError(ctx, "Invalid costume for this staff member");
+            return JS_EXCEPTION;
+        }
 
         peep->AnimationObjectIndex = costume->objectId;
         peep->AnimationGroup = costume->group;
         peep->Invalidate();
+        return JS_UNDEFINED;
     }
 
-    std::shared_ptr<ScPatrolArea> ScStaff::patrolArea_get() const
+    JSValue ScStaff::patrolArea_get(JSContext* ctx, JSValue thisVal)
     {
-        return std::make_shared<ScPatrolArea>(_id);
+        auto staffId = GetEntityId(thisVal);
+        return gScPatrolArea.New(ctx, staffId);
     }
 
-    uint8_t ScStaff::orders_get() const
+    JSValue ScStaff::orders_get(JSContext* ctx, JSValue thisVal)
     {
-        auto peep = GetStaff();
-        return peep != nullptr ? peep->StaffOrders : 0;
+        auto peep = GetStaff(thisVal);
+        return JS_NewUint32(ctx, peep != nullptr ? peep->StaffOrders : 0);
     }
 
-    void ScStaff::orders_set(uint8_t value)
+    JSValue ScStaff::orders_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr)
         {
             peep->StaffOrders = value;
         }
+        return JS_UNDEFINED;
     }
 
-    const DukEnumMap<PeepAnimationType>& ScStaff::animationsByStaffType(StaffType staffType) const
+    EnumMap<PeepAnimationType> ScStaff::animationsByStaffType(StaffType staffType)
     {
         AnimationPeepType animPeepType{};
         switch (staffType)
@@ -257,33 +271,36 @@ namespace OpenRCT2::Scripting
         return getAnimationsByPeepType(animPeepType);
     }
 
-    std::vector<std::string> ScStaff::availableAnimations_get() const
+    JSValue ScStaff::availableAnimations_get(JSContext* ctx, JSValue thisVal)
     {
-        std::vector<std::string> availableAnimations{};
+        JSValue availableAnimations = JS_NewArray(ctx);
 
-        auto* peep = GetStaff();
+        auto* peep = GetStaff(thisVal);
         if (peep != nullptr)
         {
+            auto idx = 0;
             for (auto& animation : animationsByStaffType(peep->AssignedStaffType))
             {
-                availableAnimations.push_back(std::string(animation.first));
+                JS_SetPropertyInt64(ctx, availableAnimations, idx++, JSFromStdString(ctx, animation.first));
             }
         }
 
         return availableAnimations;
     }
 
-    std::vector<uint32_t> ScStaff::getAnimationSpriteIds(std::string groupKey, uint8_t rotation) const
+    JSValue ScStaff::getAnimationSpriteIds(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        std::vector<uint32_t> spriteIds{};
+        JS_UNPACK_STR(groupKey, ctx, argv[1]);
+        JS_UNPACK_UINT32(rotation, ctx, argv[2]);
+        JSValue spriteIds = JS_NewArray(ctx);
 
-        auto* peep = GetStaff();
+        auto* peep = GetStaff(thisVal);
         if (peep == nullptr)
         {
             return spriteIds;
         }
 
-        auto& animationGroups = animationsByStaffType(peep->AssignedStaffType);
+        auto animationGroups = animationsByStaffType(peep->AssignedStaffType);
         auto animationType = animationGroups.TryGet(groupKey);
         if (animationType == std::nullopt)
         {
@@ -294,6 +311,7 @@ namespace OpenRCT2::Scripting
         auto* animObj = objManager.GetLoadedObject<PeepAnimationsObject>(peep->AnimationObjectIndex);
 
         const auto& animationGroup = animObj->GetPeepAnimation(peep->AnimationGroup, *animationType);
+        auto idx = 0;
         for (auto frameOffset : animationGroup.frame_offsets)
         {
             auto imageId = animationGroup.base_image;
@@ -302,35 +320,36 @@ namespace OpenRCT2::Scripting
             else
                 imageId += frameOffset;
 
-            spriteIds.push_back(imageId);
+            JS_SetPropertyInt64(ctx, spriteIds, idx++, JS_NewUint32(ctx, imageId));
         }
 
         return spriteIds;
     }
 
-    std::string ScStaff::animation_get() const
+    JSValue ScStaff::animation_get(JSContext* ctx, JSValue thisVal)
     {
-        auto* peep = GetStaff();
+        auto* peep = GetStaff(thisVal);
         if (peep == nullptr)
         {
-            return nullptr;
+            return JS_NULL;
         }
 
-        auto& animationGroups = animationsByStaffType(peep->AssignedStaffType);
-        std::string_view action = animationGroups[peep->AnimationType];
-        return std::string(action);
+        auto animationGroups = animationsByStaffType(peep->AssignedStaffType);
+        return JSFromStdString(ctx, animationGroups[peep->AnimationType]);
     }
 
-    void ScStaff::animation_set(std::string groupKey)
+    JSValue ScStaff::animation_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
+        JS_UNPACK_STR(groupKey, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
-        auto* peep = GetStaff();
-        auto& animationGroups = animationsByStaffType(peep->AssignedStaffType);
+        auto* peep = GetStaff(thisVal);
+        auto animationGroups = animationsByStaffType(peep->AssignedStaffType);
         auto newType = animationGroups.TryGet(groupKey);
         if (newType == std::nullopt)
         {
-            throw DukException() << "Invalid animation for this staff member (" << groupKey << ")";
+            JS_ThrowPlainError(ctx, "Invalid animation for this staff member (%s)", groupKey.data());
+            return JS_EXCEPTION;
         }
 
         peep->AnimationType = peep->NextAnimationType = *newType;
@@ -349,27 +368,27 @@ namespace OpenRCT2::Scripting
         peep->Invalidate();
         peep->UpdateSpriteBoundingBox();
         peep->Invalidate();
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScStaff::animationOffset_get() const
+    JSValue ScStaff::animationOffset_get(JSContext* ctx, JSValue thisVal)
     {
-        auto* peep = GetStaff();
+        auto* peep = GetStaff(thisVal);
         if (peep == nullptr)
         {
-            return 0;
+            return JS_NewUint32(ctx, 0);
         }
 
-        if (peep->IsActionWalking())
-            return peep->WalkingAnimationFrameNum;
-        else
-            return peep->AnimationFrameNum;
+        auto frame = peep->IsActionWalking() ? peep->WalkingAnimationFrameNum : peep->AnimationFrameNum;
+        return JS_NewUint32(ctx, frame);
     }
 
-    void ScStaff::animationOffset_set(uint8_t offset)
+    JSValue ScStaff::animationOffset_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
+        JS_UNPACK_UINT32(offset, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
-        auto* peep = GetStaff();
+        auto* peep = GetStaff(thisVal);
 
         auto& objManager = GetContext()->GetObjectManager();
         auto* animObj = objManager.GetLoadedObject<PeepAnimationsObject>(peep->AnimationObjectIndex);
@@ -387,230 +406,206 @@ namespace OpenRCT2::Scripting
         peep->Invalidate();
         peep->UpdateSpriteBoundingBox();
         peep->Invalidate();
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScStaff::animationLength_get() const
+    JSValue ScStaff::animationLength_get(JSContext* ctx, JSValue thisVal)
     {
-        auto* peep = GetStaff();
+        auto* peep = GetStaff(thisVal);
         if (peep == nullptr)
         {
-            return 0;
+            return JS_NewUint32(ctx, 0);
         }
 
         auto& objManager = GetContext()->GetObjectManager();
         auto* animObj = objManager.GetLoadedObject<PeepAnimationsObject>(peep->AnimationObjectIndex);
 
         const auto& animationGroup = animObj->GetPeepAnimation(peep->AnimationGroup, peep->AnimationType);
-        return static_cast<uint8_t>(animationGroup.frame_offsets.size());
+        auto length = static_cast<uint8_t>(animationGroup.frame_offsets.size());
+        return JS_NewUint32(ctx, length);
     }
 
-    ScHandyman::ScHandyman(EntityId Id)
-        : ScStaff(Id)
+    void ScHandyman::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("lawnsMown", &ScHandyman::lawnsMown_get, nullptr),
+            JS_CGETSET_DEF("gardensWatered", &ScHandyman::gardensWatered_get, nullptr),
+            JS_CGETSET_DEF("litterSwept", &ScHandyman::litterSwept_get, nullptr),
+            JS_CGETSET_DEF("binsEmptied", &ScHandyman::binsEmptied_get, nullptr),
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScHandyman::Register(duk_context* ctx)
+    JSValue ScHandyman::lawnsMown_get(JSContext* ctx, JSValue thisVal)
     {
-        dukglue_set_base_class<ScStaff, ScHandyman>(ctx);
-        dukglue_register_property(ctx, &ScHandyman::lawnsMown_get, nullptr, "lawnsMown");
-        dukglue_register_property(ctx, &ScHandyman::gardensWatered_get, nullptr, "gardensWatered");
-        dukglue_register_property(ctx, &ScHandyman::litterSwept_get, nullptr, "litterSwept");
-        dukglue_register_property(ctx, &ScHandyman::binsEmptied_get, nullptr, "binsEmptied");
-    }
-
-    Staff* ScHandyman::GetHandyman() const
-    {
-        return OpenRCT2::GetEntity<Staff>(_id);
-    }
-
-    DukValue ScHandyman::lawnsMown_get() const
-    {
-        auto& scriptEngine = GetContext()->GetScriptEngine();
-        auto* ctx = scriptEngine.GetContext();
-        auto peep = GetHandyman();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
-            duk_push_uint(ctx, peep->StaffLawnsMown);
+            return JS_NewUint32(ctx, peep->StaffLawnsMown);
         }
         else
         {
-            duk_push_null(ctx);
+            return JS_NULL;
         }
-        return DukValue::take_from_stack(ctx);
     }
 
-    DukValue ScHandyman::gardensWatered_get() const
+    JSValue ScHandyman::gardensWatered_get(JSContext* ctx, JSValue thisVal)
     {
-        auto& scriptEngine = GetContext()->GetScriptEngine();
-        auto* ctx = scriptEngine.GetContext();
-        auto peep = GetHandyman();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
-            duk_push_uint(ctx, peep->StaffGardensWatered);
+            return JS_NewUint32(ctx, peep->StaffGardensWatered);
         }
         else
         {
-            duk_push_null(ctx);
+            return JS_NULL;
         }
-        return DukValue::take_from_stack(ctx);
     }
 
-    DukValue ScHandyman::litterSwept_get() const
+    JSValue ScHandyman::litterSwept_get(JSContext* ctx, JSValue thisVal)
     {
-        auto& scriptEngine = GetContext()->GetScriptEngine();
-        auto* ctx = scriptEngine.GetContext();
-        auto peep = GetHandyman();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
-            duk_push_uint(ctx, peep->StaffLitterSwept);
+            return JS_NewUint32(ctx, peep->StaffLitterSwept);
         }
         else
         {
-            duk_push_null(ctx);
+            return JS_NULL;
         }
-        return DukValue::take_from_stack(ctx);
     }
 
-    DukValue ScHandyman::binsEmptied_get() const
+    JSValue ScHandyman::binsEmptied_get(JSContext* ctx, JSValue thisVal)
     {
-        auto& scriptEngine = GetContext()->GetScriptEngine();
-        auto* ctx = scriptEngine.GetContext();
-        auto peep = GetHandyman();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
-            duk_push_uint(ctx, peep->StaffBinsEmptied);
+            return JS_NewUint32(ctx, peep->StaffBinsEmptied);
         }
         else
         {
-            duk_push_null(ctx);
+            return JS_NULL;
         }
-        return DukValue::take_from_stack(ctx);
     }
 
-    ScMechanic::ScMechanic(EntityId Id)
-        : ScStaff(Id)
+    void ScMechanic::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("ridesFixed", &ScMechanic::ridesFixed_get, nullptr),
+            JS_CGETSET_DEF("ridesInspected", &ScMechanic::ridesInspected_get, nullptr),
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScMechanic::Register(duk_context* ctx)
+    JSValue ScMechanic::ridesFixed_get(JSContext* ctx, JSValue thisVal)
     {
-        dukglue_set_base_class<ScStaff, ScMechanic>(ctx);
-        dukglue_register_property(ctx, &ScMechanic::ridesFixed_get, nullptr, "ridesFixed");
-        dukglue_register_property(ctx, &ScMechanic::ridesInspected_get, nullptr, "ridesInspected");
-    }
-
-    Staff* ScMechanic::GetMechanic() const
-    {
-        return OpenRCT2::GetEntity<Staff>(_id);
-    }
-
-    DukValue ScMechanic::ridesFixed_get() const
-    {
-        auto& scriptEngine = GetContext()->GetScriptEngine();
-        auto* ctx = scriptEngine.GetContext();
-        auto peep = GetMechanic();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
         {
-            duk_push_uint(ctx, peep->StaffRidesFixed);
+            return JS_NewUint32(ctx, peep->StaffRidesFixed);
         }
         else
         {
-            duk_push_null(ctx);
+            return JS_NULL;
         }
-        return DukValue::take_from_stack(ctx);
     }
 
-    DukValue ScMechanic::ridesInspected_get() const
+    JSValue ScMechanic::ridesInspected_get(JSContext* ctx, JSValue thisVal)
     {
-        auto& scriptEngine = GetContext()->GetScriptEngine();
-        auto* ctx = scriptEngine.GetContext();
-        auto peep = GetMechanic();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
         {
-            duk_push_uint(ctx, peep->StaffRidesInspected);
+            return JS_NewUint32(ctx, peep->StaffRidesInspected);
         }
         else
         {
-            duk_push_null(ctx);
+            return JS_NULL;
         }
-        return DukValue::take_from_stack(ctx);
     }
 
-    ScSecurity::ScSecurity(EntityId Id)
-        : ScStaff(Id)
+    void ScSecurity::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("vandalsStopped", &ScSecurity::vandalsStopped_get, nullptr),
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScSecurity::Register(duk_context* ctx)
+    JSValue ScSecurity::vandalsStopped_get(JSContext* ctx, JSValue thisVal)
     {
-        dukglue_set_base_class<ScStaff, ScSecurity>(ctx);
-        dukglue_register_property(ctx, &ScSecurity::vandalsStopped_get, nullptr, "vandalsStopped");
-    }
-
-    Staff* ScSecurity::GetSecurity() const
-    {
-        return OpenRCT2::GetEntity<Staff>(_id);
-    }
-
-    DukValue ScSecurity::vandalsStopped_get() const
-    {
-        auto& scriptEngine = GetContext()->GetScriptEngine();
-        auto* ctx = scriptEngine.GetContext();
-        auto peep = GetSecurity();
+        auto peep = GetStaff(thisVal);
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Security)
         {
-            duk_push_uint(ctx, peep->StaffVandalsStopped);
+            return JS_NewUint32(ctx, peep->StaffVandalsStopped);
         }
         else
         {
-            duk_push_null(ctx);
+            return JS_NULL;
         }
-        return DukValue::take_from_stack(ctx);
     }
 
-    ScPatrolArea::ScPatrolArea(EntityId id)
-        : _staffId(id)
+    extern ScPatrolArea gScPatrolArea;
+
+    using OpaquePatrolAreaData = struct
     {
+        EntityId staffId;
+    };
+
+    JSValue ScPatrolArea::New(JSContext* ctx, EntityId staffId)
+    {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("tiles", &ScPatrolArea::tiles_get, &ScPatrolArea::tiles_set),
+            JS_CFUNC_DEF("clear", 0, &ScPatrolArea::clear),
+            JS_CFUNC_DEF("add", 0, &ScPatrolArea::add),
+            JS_CFUNC_DEF("remove", 0, &ScPatrolArea::remove),
+            JS_CFUNC_DEF("contains", 0, &ScPatrolArea::contains),
+        };
+        return MakeWithOpaque(ctx, funcs, new OpaquePatrolAreaData{ staffId });
     }
 
-    void ScPatrolArea::Register(duk_context* ctx)
+    void ScPatrolArea::Register(JSContext* ctx)
     {
-        dukglue_register_property(ctx, &ScPatrolArea::tiles_get, &ScPatrolArea::tiles_set, "tiles");
-        dukglue_register_method(ctx, &ScPatrolArea::clear, "clear");
-        dukglue_register_method(ctx, &ScPatrolArea::add, "add");
-        dukglue_register_method(ctx, &ScPatrolArea::remove, "remove");
-        dukglue_register_method(ctx, &ScPatrolArea::contains, "contains");
+        RegisterBaseStr(ctx, "PatrolArea");
     }
 
-    Staff* ScPatrolArea::GetStaff() const
+    void ScPatrolArea::Finalize(JSRuntime* rt, JSValue thisVal)
     {
-        return GetEntity<Staff>(_staffId);
+        OpaquePatrolAreaData* data = gScPatrolArea.GetOpaque<OpaquePatrolAreaData*>(thisVal);
+        if (data)
+            delete data;
     }
 
-    void ScPatrolArea::ModifyArea(const DukValue& coordsOrRange, bool value) const
+    Staff* ScPatrolArea::GetStaff(JSValue thisVal)
     {
-        auto staff = GetStaff();
+        OpaquePatrolAreaData* data = gScPatrolArea.GetOpaque<OpaquePatrolAreaData*>(thisVal);
+        return GetEntity<Staff>(data->staffId);
+    }
+
+    void ScPatrolArea::ModifyArea(JSContext* ctx, JSValue thisVal, JSValue coordsOrRange, bool reset)
+    {
+        auto staff = GetStaff(thisVal);
         if (staff != nullptr)
         {
-            if (coordsOrRange.is_array())
+            if (JS_IsArray(coordsOrRange))
             {
-                auto dukCoords = coordsOrRange.as_array();
-                for (const auto& dukCoord : dukCoords)
-                {
-                    auto coord = FromDuk<CoordsXY>(dukCoord);
-                    staff->SetPatrolArea(coord, value);
+                JSIterateArray(ctx, coordsOrRange, [staff, reset](JSContext* c, JSValue v) {
+                    auto coord = JSToCoordXY(c, v);
+                    staff->SetPatrolArea(coord, reset);
                     MapInvalidateTileFull(coord);
-                }
+                });
             }
             else
             {
-                auto mapRange = FromDuk<MapRange>(coordsOrRange);
+                MapRange mapRange = {
+                    JSToCoordXY(ctx, coordsOrRange, "leftTop"),
+                    JSToCoordXY(ctx, coordsOrRange, "rightBottom")
+                };
                 for (int32_t y = mapRange.GetTop(); y <= mapRange.GetBottom(); y += kCoordsXYStep)
                 {
                     for (int32_t x = mapRange.GetLeft(); x <= mapRange.GetRight(); x += kCoordsXYStep)
                     {
                         CoordsXY coord(x, y);
-                        staff->SetPatrolArea(coord, value);
+                        staff->SetPatrolArea(coord, reset);
                         MapInvalidateTileFull(coord);
                     }
                 }
@@ -619,78 +614,82 @@ namespace OpenRCT2::Scripting
         }
     }
 
-    DukValue ScPatrolArea::tiles_get() const
+    JSValue ScPatrolArea::tiles_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
+        auto array = JS_NewArray(ctx);
 
-        duk_push_array(ctx);
-
-        auto staff = GetStaff();
+        auto staff = GetStaff(thisVal);
         if (staff != nullptr && staff->PatrolInfo != nullptr)
         {
             auto tiles = staff->PatrolInfo->ToVector();
 
-            duk_uarridx_t index = 0;
+            auto index = 0;
             for (const auto& tile : tiles)
             {
-                auto dukCoord = ToDuk(ctx, tile.ToCoordsXY());
-                dukCoord.push();
-                duk_put_prop_index(ctx, -2, index);
+                auto coords = ToJSValue(ctx, tile);
+                JS_SetPropertyInt64(ctx, array, index, coords);
                 index++;
             }
         }
 
-        return DukValue::take_from_stack(ctx, -1);
+        return array;
     }
 
-    void ScPatrolArea::tiles_set(const DukValue& value)
+    JSValue ScPatrolArea::tiles_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
-        ThrowIfGameStateNotMutable();
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
-        auto staff = GetStaff();
+        auto staff = GetStaff(thisVal);
         if (staff != nullptr)
         {
             staff->ClearPatrolArea();
-            if (value.is_array())
+            if (JS_IsArray(value))
             {
-                ModifyArea(value, true);
+                ModifyArea(ctx, thisVal, value, true);
             }
         }
+        return JS_UNDEFINED;
     }
 
-    void ScPatrolArea::clear()
+    JSValue ScPatrolArea::clear(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        ThrowIfGameStateNotMutable();
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
-        auto staff = GetStaff();
+        auto staff = GetStaff(thisVal);
         if (staff != nullptr)
         {
             staff->ClearPatrolArea();
             UpdateConsolidatedPatrolAreas();
         }
+        return JS_UNDEFINED;
     }
 
-    void ScPatrolArea::add(const DukValue& coordsOrRange)
+    JSValue ScPatrolArea::add(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        ThrowIfGameStateNotMutable();
-        ModifyArea(coordsOrRange, true);
+        JS_UNPACK_OBJECT(coordsOrRange, ctx, argv[1]) // todo out of bounds?
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        ModifyArea(ctx, thisVal, coordsOrRange, true);
+        return JS_UNDEFINED;
     }
 
-    void ScPatrolArea::remove(const DukValue& coordsOrRange)
+    JSValue ScPatrolArea::remove(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        ThrowIfGameStateNotMutable();
-        ModifyArea(coordsOrRange, false);
+        JS_UNPACK_OBJECT(coordsOrRange, ctx, argv[1]) // todo out of bounds?
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        ModifyArea(ctx, thisVal, coordsOrRange, false);
+        return JS_UNDEFINED;
     }
 
-    bool ScPatrolArea::contains(const DukValue& coord) const
+    JSValue ScPatrolArea::contains(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        auto staff = GetStaff();
+        JS_UNPACK_OBJECT(coord, ctx, argv[1]) // todo out of bounds?
+        auto staff = GetStaff(thisVal);
         if (staff != nullptr)
         {
-            auto pos = FromDuk<CoordsXY>(coord);
-            return staff->IsLocationInPatrol(pos);
+            auto pos = JSToCoordXY(ctx, coord);
+            return JS_NewBool(ctx, staff->IsLocationInPatrol(pos));
         }
-        return false;
+        return JS_NewBool(ctx, false);
     }
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -544,8 +544,6 @@ namespace OpenRCT2::Scripting
         }
     }
 
-    extern ScPatrolArea gScPatrolArea;
-
     using OpaquePatrolAreaData = struct
     {
         EntityId staffId;

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -565,7 +565,7 @@ namespace OpenRCT2::Scripting
 
     void ScPatrolArea::Register(JSContext* ctx)
     {
-        RegisterBaseStr(ctx, "PatrolArea");
+        RegisterBaseStr(ctx, "PatrolArea", Finalize);
     }
 
     void ScPatrolArea::Finalize(JSRuntime* rt, JSValue thisVal)

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -290,8 +290,8 @@ namespace OpenRCT2::Scripting
 
     JSValue ScStaff::getAnimationSpriteIds(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_STR(groupKey, ctx, argv[1]);
-        JS_UNPACK_UINT32(rotation, ctx, argv[2]);
+        JS_UNPACK_STR(groupKey, ctx, argv[0]);
+        JS_UNPACK_UINT32(rotation, ctx, argv[1]);
         JSValue spriteIds = JS_NewArray(ctx);
 
         auto* peep = GetStaff(thisVal);
@@ -596,10 +596,8 @@ namespace OpenRCT2::Scripting
             }
             else
             {
-                MapRange mapRange = {
-                    JSToCoordXY(ctx, coordsOrRange, "leftTop"),
-                    JSToCoordXY(ctx, coordsOrRange, "rightBottom")
-                };
+                MapRange mapRange = { JSToCoordXY(ctx, coordsOrRange, "leftTop"),
+                                      JSToCoordXY(ctx, coordsOrRange, "rightBottom") };
                 for (int32_t y = mapRange.GetTop(); y <= mapRange.GetBottom(); y += kCoordsXYStep)
                 {
                     for (int32_t x = mapRange.GetLeft(); x <= mapRange.GetRight(); x += kCoordsXYStep)
@@ -666,7 +664,7 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPatrolArea::add(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_OBJECT(coordsOrRange, ctx, argv[1]) // todo out of bounds?
+        JS_UNPACK_OBJECT(coordsOrRange, ctx, argv[0])
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
         ModifyArea(ctx, thisVal, coordsOrRange, true);
         return JS_UNDEFINED;
@@ -674,7 +672,7 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPatrolArea::remove(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_OBJECT(coordsOrRange, ctx, argv[1]) // todo out of bounds?
+        JS_UNPACK_OBJECT(coordsOrRange, ctx, argv[0])
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
         ModifyArea(ctx, thisVal, coordsOrRange, false);
         return JS_UNDEFINED;
@@ -682,7 +680,7 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPatrolArea::contains(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_OBJECT(coord, ctx, argv[1]) // todo out of bounds?
+        JS_UNPACK_OBJECT(coord, ctx, argv[0])
         auto staff = GetStaff(thisVal);
         if (staff != nullptr)
         {

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -556,9 +556,9 @@ namespace OpenRCT2::Scripting
         static constexpr JSCFunctionListEntry funcs[] = {
             JS_CGETSET_DEF("tiles", &ScPatrolArea::tiles_get, &ScPatrolArea::tiles_set),
             JS_CFUNC_DEF("clear", 0, &ScPatrolArea::clear),
-            JS_CFUNC_DEF("add", 0, &ScPatrolArea::add),
-            JS_CFUNC_DEF("remove", 0, &ScPatrolArea::remove),
-            JS_CFUNC_DEF("contains", 0, &ScPatrolArea::contains),
+            JS_CFUNC_DEF("add", 1, &ScPatrolArea::add),
+            JS_CFUNC_DEF("remove", 1, &ScPatrolArea::remove),
+            JS_CFUNC_DEF("contains", 1, &ScPatrolArea::contains),
         };
         return MakeWithOpaque(ctx, funcs, new OpaquePatrolAreaData{ staffId });
     }

--- a/src/openrct2/scripting/bindings/entity/ScStaff.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "ScPeep.hpp"
 
@@ -20,110 +20,97 @@ enum class StaffType : uint8_t;
 
 namespace OpenRCT2::Scripting
 {
-    class ScPatrolArea
+    class ScPatrolArea;
+    extern ScPatrolArea gScPatrolArea;
+
+    class ScPatrolArea final : public ScBase
     {
-    private:
-        EntityId _staffId;
-
     public:
-        ScPatrolArea(EntityId id);
-
-        static void Register(duk_context* ctx);
+        JSValue New(JSContext* ctx, EntityId staffId);
+        void Register(JSContext* ctx);
 
     private:
-        Staff* GetStaff() const;
-        void ModifyArea(const DukValue& coordsOrRange, bool value) const;
+        static void Finalize(JSRuntime* rt, JSValue thisVal);
+        static Staff* GetStaff(JSValue thisVal);
+        static void ModifyArea(JSContext* ctx, JSValue thisVal, JSValue coordsOrRange, bool reset);
 
-        DukValue tiles_get() const;
-        void tiles_set(const DukValue& value);
+        static JSValue tiles_get(JSContext* ctx, JSValue thisVal);
+        static JSValue tiles_set(JSContext* ctx, JSValue thisVal, JSValue value);
 
-        void clear();
-        void add(const DukValue& coordsOrRange);
-        void remove(const DukValue& coordsOrRange);
-        bool contains(const DukValue& coord) const;
+        static JSValue clear(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
+        static JSValue add(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
+        static JSValue remove(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
+        static JSValue contains(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
     };
 
     class ScStaff : public ScPeep
     {
     public:
-        ScStaff(EntityId Id);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
-        static void Register(duk_context* ctx);
+    protected:
+        static Staff* GetStaff(JSValue thisVal);
 
     private:
-        Staff* GetStaff() const;
+        static JSValue staffType_get(JSContext* ctx, JSValue thisVal);
+        static JSValue staffType_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        std::string staffType_get() const;
-        void staffType_set(const std::string& value);
+        static JSValue colour_get(JSContext* ctx, JSValue thisVal);
+        static JSValue colour_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t colour_get() const;
-        void colour_set(uint8_t value);
+        static JSValue availableCostumes_get(JSContext* ctx, JSValue thisVal);
+        static JSValue getCostumeStrings(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
+        static JSValue costume_get(JSContext* ctx, JSValue thisVal);
+        static JSValue costume_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        std::vector<std::string> availableCostumes_get() const;
-        std::vector<std::string> getCostumeStrings() const;
-        std::string costume_get() const;
-        void costume_set(const DukValue& value);
+        static JSValue patrolArea_get(JSContext* ctx, JSValue thisVal);
 
-        std::shared_ptr<ScPatrolArea> patrolArea_get() const;
+        static JSValue orders_get(JSContext* ctx, JSValue thisVal);
+        static JSValue orders_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t orders_get() const;
-        void orders_set(uint8_t value);
-
-        const DukEnumMap<PeepAnimationType>& animationsByStaffType(StaffType staffType) const;
-        std::vector<uint32_t> getAnimationSpriteIds(std::string groupKey, uint8_t rotation) const;
-        std::vector<std::string> availableAnimations_get() const;
-        std::string animation_get() const;
-        void animation_set(std::string groupKey);
-        uint8_t animationOffset_get() const;
-        void animationOffset_set(uint8_t offset);
-        uint8_t animationLength_get() const;
+        static EnumMap<PeepAnimationType> animationsByStaffType(StaffType staffType);
+        static JSValue getAnimationSpriteIds(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
+        static JSValue availableAnimations_get(JSContext* ctx, JSValue thisVal);
+        static JSValue animation_get(JSContext* ctx, JSValue thisVal);
+        static JSValue animation_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
+        static JSValue animationOffset_get(JSContext* ctx, JSValue thisVal);
+        static JSValue animationOffset_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
+        static JSValue animationLength_get(JSContext* ctx, JSValue thisVal);
     };
 
-    class ScHandyman : public ScStaff
+    class ScHandyman final : public ScStaff
     {
     public:
-        ScHandyman(EntityId Id);
-
-        static void Register(duk_context* ctx);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
     private:
-        Staff* GetHandyman() const;
+        static JSValue lawnsMown_get(JSContext* ctx, JSValue thisVal);
 
-        DukValue lawnsMown_get() const;
+        static JSValue gardensWatered_get(JSContext* ctx, JSValue thisVal);
 
-        DukValue gardensWatered_get() const;
+        static JSValue litterSwept_get(JSContext* ctx, JSValue thisVal);
 
-        DukValue litterSwept_get() const;
-
-        DukValue binsEmptied_get() const;
+        static JSValue binsEmptied_get(JSContext* ctx, JSValue thisVal);
     };
 
-    class ScMechanic : public ScStaff
+    class ScMechanic final : public ScStaff
     {
     public:
-        ScMechanic(EntityId Id);
-
-        static void Register(duk_context* ctx);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
     private:
-        Staff* GetMechanic() const;
+        static JSValue ridesFixed_get(JSContext* ctx, JSValue thisVal);
 
-        DukValue ridesFixed_get() const;
-
-        DukValue ridesInspected_get() const;
+        static JSValue ridesInspected_get(JSContext* ctx, JSValue thisVal);
     };
 
-    class ScSecurity : public ScStaff
+    class ScSecurity final : public ScStaff
     {
     public:
-        ScSecurity(EntityId Id);
-
-        static void Register(duk_context* ctx);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
     private:
-        Staff* GetSecurity() const;
-
-        DukValue vandalsStopped_get() const;
+        static JSValue vandalsStopped_get(JSContext* ctx, JSValue thisVal);
     };
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -567,7 +567,7 @@ namespace OpenRCT2::Scripting
 
     JSValue ScVehicle::travelBy(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_INT32(value, ctx, argv[1]);
+        JS_UNPACK_INT32(value, ctx, argv[0]);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
         auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
@@ -580,9 +580,9 @@ namespace OpenRCT2::Scripting
 
     JSValue ScVehicle::moveToTrack(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        JS_UNPACK_INT32(x, ctx, argv[1]);
-        JS_UNPACK_INT32(y, ctx, argv[2]);
-        JS_UNPACK_INT32(elementIndex, ctx, argv[3]);
+        JS_UNPACK_INT32(x, ctx, argv[0]);
+        JS_UNPACK_INT32(y, ctx, argv[1]);
+        JS_UNPACK_INT32(elementIndex, ctx, argv[2]);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
         auto vehicle = GetVehicle(thisVal);
         if (vehicle == nullptr)

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -9,358 +9,378 @@
 
 #include "ScVehicle.hpp"
 
+#include "../../../core/EnumMap.hpp"
 #include "../../../ride/TrackData.h"
+#include "../../../ride/Vehicle.h"
 #include "../../../world/tile_element/TrackElement.h"
 #include "../ride/ScRide.hpp"
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
 using namespace OpenRCT2::Drawing;
 using namespace OpenRCT2::TrackMetaData;
 
 namespace OpenRCT2::Scripting
 {
-    static const DukEnumMap<Vehicle::Status> VehicleStatusMap(
-        {
-            { "moving_to_end_of_station", Vehicle::Status::MovingToEndOfStation },
-            { "waiting_for_passengers", Vehicle::Status::WaitingForPassengers },
-            { "waiting_to_depart", Vehicle::Status::WaitingToDepart },
-            { "departing", Vehicle::Status::Departing },
-            { "travelling", Vehicle::Status::Travelling },
-            { "arriving", Vehicle::Status::Arriving },
-            { "unloading_passengers", Vehicle::Status::UnloadingPassengers },
-            { "travelling_boat", Vehicle::Status::TravellingBoat },
-            { "crashing", Vehicle::Status::Crashing },
-            { "crashed", Vehicle::Status::Crashed },
-            { "travelling_dodgems", Vehicle::Status::TravellingDodgems },
-            { "swinging", Vehicle::Status::Swinging },
-            { "rotating", Vehicle::Status::Rotating },
-            { "ferris_wheel_rotating", Vehicle::Status::FerrisWheelRotating },
-            { "simulator_operating", Vehicle::Status::SimulatorOperating },
-            { "showing_film", Vehicle::Status::ShowingFilm },
-            { "space_rings_operating", Vehicle::Status::SpaceRingsOperating },
-            { "top_spin_operating", Vehicle::Status::TopSpinOperating },
-            { "haunted_house_operating", Vehicle::Status::HauntedHouseOperating },
-            { "doing_circus_show", Vehicle::Status::DoingCircusShow },
-            { "crooked_house_operating", Vehicle::Status::CrookedHouseOperating },
-            { "waiting_for_cable_lift", Vehicle::Status::WaitingForCableLift },
-            { "travelling_cable_lift", Vehicle::Status::TravellingCableLift },
-            { "stopping", Vehicle::Status::Stopping },
-            { "waiting_for_passengers_17", Vehicle::Status::WaitingForPassengers17 },
-            { "waiting_to_start", Vehicle::Status::WaitingToStart },
-            { "starting", Vehicle::Status::Starting },
-            { "operating_1a", Vehicle::Status::Operating1A },
-            { "stopping_1b", Vehicle::Status::Stopping1B },
-            { "unloading_passengers_1c", Vehicle::Status::UnloadingPassengers1C },
-            { "stopped_by_block_brake", Vehicle::Status::StoppedByBlockBrakes },
-        });
+    static const EnumMap<Vehicle::Status> VehicleStatusMap({
+        { "moving_to_end_of_station", Vehicle::Status::MovingToEndOfStation },
+        { "waiting_for_passengers", Vehicle::Status::WaitingForPassengers },
+        { "waiting_to_depart", Vehicle::Status::WaitingToDepart },
+        { "departing", Vehicle::Status::Departing },
+        { "travelling", Vehicle::Status::Travelling },
+        { "arriving", Vehicle::Status::Arriving },
+        { "unloading_passengers", Vehicle::Status::UnloadingPassengers },
+        { "travelling_boat", Vehicle::Status::TravellingBoat },
+        { "crashing", Vehicle::Status::Crashing },
+        { "crashed", Vehicle::Status::Crashed },
+        { "travelling_dodgems", Vehicle::Status::TravellingDodgems },
+        { "swinging", Vehicle::Status::Swinging },
+        { "rotating", Vehicle::Status::Rotating },
+        { "ferris_wheel_rotating", Vehicle::Status::FerrisWheelRotating },
+        { "simulator_operating", Vehicle::Status::SimulatorOperating },
+        { "showing_film", Vehicle::Status::ShowingFilm },
+        { "space_rings_operating", Vehicle::Status::SpaceRingsOperating },
+        { "top_spin_operating", Vehicle::Status::TopSpinOperating },
+        { "haunted_house_operating", Vehicle::Status::HauntedHouseOperating },
+        { "doing_circus_show", Vehicle::Status::DoingCircusShow },
+        { "crooked_house_operating", Vehicle::Status::CrookedHouseOperating },
+        { "waiting_for_cable_lift", Vehicle::Status::WaitingForCableLift },
+        { "travelling_cable_lift", Vehicle::Status::TravellingCableLift },
+        { "stopping", Vehicle::Status::Stopping },
+        { "waiting_for_passengers_17", Vehicle::Status::WaitingForPassengers17 },
+        { "waiting_to_start", Vehicle::Status::WaitingToStart },
+        { "starting", Vehicle::Status::Starting },
+        { "operating_1a", Vehicle::Status::Operating1A },
+        { "stopping_1b", Vehicle::Status::Stopping1B },
+        { "unloading_passengers_1c", Vehicle::Status::UnloadingPassengers1C },
+        { "stopped_by_block_brake", Vehicle::Status::StoppedByBlockBrakes },
+    });
 
-    ScVehicle::ScVehicle(EntityId id)
-        : ScEntity(id)
+    void ScVehicle::AddFuncs(JSContext* ctx, JSValue obj)
     {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("ride", &ScVehicle::ride_get, &ScVehicle::ride_set),
+            JS_CGETSET_DEF("rideObject", &ScVehicle::rideObject_get, &ScVehicle::rideObject_set),
+            JS_CGETSET_DEF("vehicleObject", &ScVehicle::vehicleObject_get, &ScVehicle::vehicleObject_set),
+            JS_CGETSET_DEF("spriteType", &ScVehicle::spriteType_get, &ScVehicle::spriteType_set),
+            JS_CGETSET_DEF("numSeats", &ScVehicle::numSeats_get, &ScVehicle::numSeats_set),
+            JS_CGETSET_DEF("nextCarOnTrain", &ScVehicle::nextCarOnTrain_get, &ScVehicle::nextCarOnTrain_set),
+            JS_CGETSET_DEF("previousCarOnRide", &ScVehicle::previousCarOnRide_get, &ScVehicle::previousCarOnRide_set),
+            JS_CGETSET_DEF("nextCarOnRide", &ScVehicle::nextCarOnRide_get, &ScVehicle::nextCarOnRide_set),
+            JS_CGETSET_DEF("currentStation", &ScVehicle::currentStation_get, &ScVehicle::currentStation_set),
+            JS_CGETSET_DEF("mass", &ScVehicle::mass_get, &ScVehicle::mass_set),
+            JS_CGETSET_DEF("acceleration", &ScVehicle::acceleration_get, &ScVehicle::acceleration_set),
+            JS_CGETSET_DEF("velocity", &ScVehicle::velocity_get, &ScVehicle::velocity_set),
+            JS_CGETSET_DEF("bankRotation", &ScVehicle::bankRotation_get, &ScVehicle::bankRotation_set),
+            JS_CGETSET_DEF(
+                "isReversed", &ScVehicle::flag_get<VehicleFlags::CarIsReversed>,
+                &ScVehicle::flag_set<VehicleFlags::CarIsReversed>),
+            JS_CGETSET_DEF(
+                "isCrashed", &ScVehicle::flag_get<VehicleFlags::Crashed>, &ScVehicle::flag_set<VehicleFlags::Crashed>),
+            JS_CGETSET_DEF("colours", &ScVehicle::colours_get, &ScVehicle::colours_set),
+            JS_CGETSET_DEF("trackLocation", &ScVehicle::trackLocation_get, nullptr),
+            JS_CGETSET_DEF("trackProgress", &ScVehicle::trackProgress_get, nullptr),
+            JS_CGETSET_DEF("remainingDistance", &ScVehicle::remainingDistance_get, nullptr),
+            JS_CGETSET_DEF("subposition", &ScVehicle::subposition_get, nullptr),
+            JS_CGETSET_DEF("poweredAcceleration", &ScVehicle::poweredAcceleration_get, &ScVehicle::poweredAcceleration_set),
+            JS_CGETSET_DEF("poweredMaxSpeed", &ScVehicle::poweredMaxSpeed_get, &ScVehicle::poweredMaxSpeed_set),
+            JS_CGETSET_DEF("status", &ScVehicle::status_get, &ScVehicle::status_set),
+            JS_CGETSET_DEF("spin", &ScVehicle::spin_get, &ScVehicle::spin_set),
+            JS_CGETSET_DEF("peeps", &ScVehicle::guests_get, nullptr),
+            JS_CGETSET_DEF("guests", &ScVehicle::guests_get, nullptr),
+            JS_CGETSET_DEF("gForces", &ScVehicle::gForces_get, nullptr),
+            JS_CFUNC_DEF("travelBy", 1, &ScVehicle::travelBy),
+            JS_CFUNC_DEF("moveToTrack", 3, &ScVehicle::moveToTrack),
+        };
+        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
     }
 
-    void ScVehicle::Register(duk_context* ctx)
+    Vehicle* ScVehicle::GetVehicle(JSValue thisVal)
     {
-        dukglue_set_base_class<ScEntity, ScVehicle>(ctx);
-        dukglue_register_property(ctx, &ScVehicle::ride_get, &ScVehicle::ride_set, "ride");
-        dukglue_register_property(ctx, &ScVehicle::rideObject_get, &ScVehicle::rideObject_set, "rideObject");
-        dukglue_register_property(ctx, &ScVehicle::vehicleObject_get, &ScVehicle::vehicleObject_set, "vehicleObject");
-        dukglue_register_property(ctx, &ScVehicle::spriteType_get, &ScVehicle::spriteType_set, "spriteType");
-        dukglue_register_property(ctx, &ScVehicle::numSeats_get, &ScVehicle::numSeats_set, "numSeats");
-        dukglue_register_property(ctx, &ScVehicle::nextCarOnTrain_get, &ScVehicle::nextCarOnTrain_set, "nextCarOnTrain");
-        dukglue_register_property(
-            ctx, &ScVehicle::previousCarOnRide_get, &ScVehicle::previousCarOnRide_set, "previousCarOnRide");
-        dukglue_register_property(ctx, &ScVehicle::nextCarOnRide_get, &ScVehicle::nextCarOnRide_set, "nextCarOnRide");
-        dukglue_register_property(ctx, &ScVehicle::currentStation_get, &ScVehicle::currentStation_set, "currentStation");
-        dukglue_register_property(ctx, &ScVehicle::mass_get, &ScVehicle::mass_set, "mass");
-        dukglue_register_property(ctx, &ScVehicle::acceleration_get, &ScVehicle::acceleration_set, "acceleration");
-        dukglue_register_property(ctx, &ScVehicle::velocity_get, &ScVehicle::velocity_set, "velocity");
-        dukglue_register_property(ctx, &ScVehicle::bankRotation_get, &ScVehicle::bankRotation_set, "bankRotation");
-        dukglue_register_property(
-            ctx, &ScVehicle::flag_get<VehicleFlags::CarIsReversed>, &ScVehicle::flag_set<VehicleFlags::CarIsReversed>,
-            "isReversed");
-        dukglue_register_property(
-            ctx, &ScVehicle::flag_get<VehicleFlags::Crashed>, &ScVehicle::flag_set<VehicleFlags::Crashed>, "isCrashed");
-        dukglue_register_property(ctx, &ScVehicle::colours_get, &ScVehicle::colours_set, "colours");
-        dukglue_register_property(ctx, &ScVehicle::trackLocation_get, nullptr, "trackLocation");
-        dukglue_register_property(ctx, &ScVehicle::trackProgress_get, nullptr, "trackProgress");
-        dukglue_register_property(ctx, &ScVehicle::remainingDistance_get, nullptr, "remainingDistance");
-        dukglue_register_property(ctx, &ScVehicle::subposition_get, nullptr, "subposition");
-        dukglue_register_property(
-            ctx, &ScVehicle::poweredAcceleration_get, &ScVehicle::poweredAcceleration_set, "poweredAcceleration");
-        dukglue_register_property(ctx, &ScVehicle::poweredMaxSpeed_get, &ScVehicle::poweredMaxSpeed_set, "poweredMaxSpeed");
-        dukglue_register_property(ctx, &ScVehicle::status_get, &ScVehicle::status_set, "status");
-        dukglue_register_property(ctx, &ScVehicle::spin_get, &ScVehicle::spin_set, "spin");
-        dukglue_register_property(ctx, &ScVehicle::guests_get, nullptr, "peeps");
-        dukglue_register_property(ctx, &ScVehicle::guests_get, nullptr, "guests");
-        dukglue_register_property(ctx, &ScVehicle::gForces_get, nullptr, "gForces");
-        dukglue_register_method(ctx, &ScVehicle::travelBy, "travelBy");
-        dukglue_register_method(ctx, &ScVehicle::moveToTrack, "moveToTrack");
+        auto id = GetEntityId(thisVal);
+        return ::GetEntity<Vehicle>(id);
     }
 
-    Vehicle* ScVehicle::GetVehicle() const
+    JSValue ScVehicle::rideObject_get(JSContext* ctx, JSValue thisVal)
     {
-        return ::GetEntity<Vehicle>(_id);
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->ride_subtype : 0);
     }
-
-    ObjectEntryIndex ScVehicle::rideObject_get() const
+    JSValue ScVehicle::rideObject_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->ride_subtype : 0;
-    }
-    void ScVehicle::rideObject_set(ObjectEntryIndex value)
-    {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->ride_subtype = value;
             vehicle->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScVehicle::vehicleObject_get() const
+    JSValue ScVehicle::vehicleObject_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->vehicle_type : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->vehicle_type : 0);
     }
-    void ScVehicle::vehicleObject_set(uint8_t value)
+    JSValue ScVehicle::vehicleObject_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->vehicle_type = value;
             vehicle->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScVehicle::spriteType_get() const
+    JSValue ScVehicle::spriteType_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->Pitch : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->Pitch : 0);
     }
-    void ScVehicle::spriteType_set(uint8_t value)
+    JSValue ScVehicle::spriteType_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->Pitch = value;
             vehicle->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    int32_t ScVehicle::ride_get() const
+    JSValue ScVehicle::ride_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return (vehicle != nullptr ? vehicle->ride : RideId::GetNull()).ToUnderlying();
+        auto vehicle = GetVehicle(thisVal);
+        auto rideId = vehicle != nullptr ? vehicle->ride : RideId::GetNull();
+        return JS_NewUint32(ctx, rideId.ToUnderlying());
     }
-    void ScVehicle::ride_set(int32_t value)
+    JSValue ScVehicle::ride_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_INT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->ride = RideId::FromUnderlying(value);
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScVehicle::numSeats_get() const
+    JSValue ScVehicle::numSeats_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->num_seats & kVehicleSeatNumMask : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->num_seats & kVehicleSeatNumMask : 0);
     }
-    void ScVehicle::numSeats_set(uint8_t value)
+    JSValue ScVehicle::numSeats_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->num_seats &= ~kVehicleSeatNumMask;
             vehicle->num_seats |= value & kVehicleSeatNumMask;
         }
+        return JS_UNDEFINED;
     }
 
-    DukValue ScVehicle::nextCarOnTrain_get() const
+    JSValue ScVehicle::nextCarOnTrain_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-        auto vehicle = GetVehicle();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             if (!vehicle->next_vehicle_on_train.IsNull())
             {
-                return ToDuk<int32_t>(ctx, vehicle->next_vehicle_on_train.ToUnderlying());
+                return JS_NewUint32(ctx, vehicle->next_vehicle_on_train.ToUnderlying());
             }
         }
-        return ToDuk(ctx, nullptr);
+        return JS_NULL;
     }
-    void ScVehicle::nextCarOnTrain_set(DukValue value)
+    JSValue ScVehicle::nextCarOnTrain_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
-            if (value.type() == DukValue::Type::NUMBER)
-            {
-                vehicle->next_vehicle_on_train = EntityId::FromUnderlying(value.as_uint());
-            }
-            else
+            if (JS_IsNull(jsValue))
             {
                 vehicle->next_vehicle_on_train = EntityId::GetNull();
             }
+            else
+            {
+                JS_UNPACK_UINT32(entityId, ctx, jsValue);
+                vehicle->next_vehicle_on_train = EntityId::FromUnderlying(entityId);
+            }
         }
+        return JS_UNDEFINED;
     }
 
-    DukValue ScVehicle::previousCarOnRide_get() const
+    JSValue ScVehicle::previousCarOnRide_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-
-        const auto* vehicle = GetVehicle();
+        const auto* vehicle = GetVehicle(thisVal);
         if (vehicle == nullptr)
-            return ToDuk(ctx, nullptr);
+            return JS_NULL;
 
         if (vehicle->prev_vehicle_on_ride.IsNull())
-            return ToDuk(ctx, nullptr);
+            return JS_NULL;
 
-        return ToDuk(ctx, vehicle->prev_vehicle_on_ride.ToUnderlying());
+        return JS_NewUint32(ctx, vehicle->prev_vehicle_on_ride.ToUnderlying());
     }
-    void ScVehicle::previousCarOnRide_set(DukValue value)
+    JSValue ScVehicle::previousCarOnRide_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto* vehicle = GetVehicle();
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto* vehicle = GetVehicle(thisVal);
         if (vehicle == nullptr)
-            return;
+            return JS_UNDEFINED;
 
-        if (value.type() == DukValue::Type::NUMBER)
-        {
-            vehicle->prev_vehicle_on_ride = EntityId::FromUnderlying(value.as_uint());
-        }
-        else
+        if (JS_IsNull(jsValue))
         {
             vehicle->prev_vehicle_on_ride = EntityId::GetNull();
         }
+        else
+        {
+            JS_UNPACK_UINT32(entityId, ctx, jsValue);
+            vehicle->prev_vehicle_on_ride = EntityId::FromUnderlying(entityId);
+        }
+        return JS_UNDEFINED;
     }
 
-    DukValue ScVehicle::nextCarOnRide_get() const
+    JSValue ScVehicle::nextCarOnRide_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-
-        const auto* vehicle = GetVehicle();
+        const auto* vehicle = GetVehicle(thisVal);
         if (vehicle == nullptr)
-            return ToDuk(ctx, nullptr);
+            return JS_NULL;
 
         if (vehicle->next_vehicle_on_ride.IsNull())
-            return ToDuk(ctx, nullptr);
+            return JS_NULL;
 
-        return ToDuk(ctx, vehicle->next_vehicle_on_ride.ToUnderlying());
+        return JS_NewUint32(ctx, vehicle->next_vehicle_on_ride.ToUnderlying());
     }
-    void ScVehicle::nextCarOnRide_set(DukValue value)
+    JSValue ScVehicle::nextCarOnRide_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto* vehicle = GetVehicle();
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto* vehicle = GetVehicle(thisVal);
         if (vehicle == nullptr)
-            return;
+            return JS_UNDEFINED;
 
-        if (value.type() == DukValue::Type::NUMBER)
-        {
-            vehicle->next_vehicle_on_ride = EntityId::FromUnderlying(value.as_uint());
-        }
-        else
+        if (JS_IsNull(jsValue))
         {
             vehicle->next_vehicle_on_ride = EntityId::GetNull();
         }
+        else
+        {
+            JS_UNPACK_UINT32(entityId, ctx, jsValue);
+            vehicle->next_vehicle_on_ride = EntityId::FromUnderlying(entityId);
+        }
+        return JS_UNDEFINED;
     }
 
-    StationIndex::UnderlyingType ScVehicle::currentStation_get() const
+    JSValue ScVehicle::currentStation_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->current_station.ToUnderlying() : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->current_station.ToUnderlying() : 0);
     }
-    void ScVehicle::currentStation_set(StationIndex::UnderlyingType value)
+    JSValue ScVehicle::currentStation_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->current_station = StationIndex::FromUnderlying(value);
         }
+        return JS_UNDEFINED;
     }
 
-    uint16_t ScVehicle::mass_get() const
+    JSValue ScVehicle::mass_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->mass : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->mass : 0);
     }
-    void ScVehicle::mass_set(uint16_t value)
+    JSValue ScVehicle::mass_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->mass = value;
         }
+        return JS_UNDEFINED;
     }
 
-    int32_t ScVehicle::acceleration_get() const
+    JSValue ScVehicle::acceleration_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->acceleration : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewInt32(ctx, vehicle != nullptr ? vehicle->acceleration : 0);
     }
-    void ScVehicle::acceleration_set(int32_t value)
+    JSValue ScVehicle::acceleration_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_INT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->acceleration = value;
         }
+        return JS_UNDEFINED;
     }
 
-    int32_t ScVehicle::velocity_get() const
+    JSValue ScVehicle::velocity_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->velocity : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewInt32(ctx, vehicle != nullptr ? vehicle->velocity : 0);
     }
-    void ScVehicle::velocity_set(int32_t value)
+    JSValue ScVehicle::velocity_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_INT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->velocity = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScVehicle::bankRotation_get() const
+    JSValue ScVehicle::bankRotation_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->bank_rotation : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->bank_rotation : 0);
     }
-    void ScVehicle::bankRotation_set(uint8_t value)
+    JSValue ScVehicle::bankRotation_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->bank_rotation = value;
             vehicle->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
     template<uint32_t flag>
-    bool ScVehicle::flag_get() const
+    JSValue ScVehicle::flag_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->HasFlag(flag) : false;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->HasFlag(flag) : false);
     }
 
     template<uint32_t flag>
-    void ScVehicle::flag_set(bool value)
+    JSValue ScVehicle::flag_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_BOOL(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             if (value)
@@ -373,196 +393,209 @@ namespace OpenRCT2::Scripting
             }
             vehicle->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    DukValue ScVehicle::colours_get() const
+    JSValue ScVehicle::colours_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-        auto vehicle = GetVehicle();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
-            return ToDuk<VehicleColour>(ctx, vehicle->colours);
+            return ToJSValue(ctx, vehicle->colours);
         }
-        return ToDuk(ctx, nullptr);
+        return JS_NULL;
     }
-    void ScVehicle::colours_set(const DukValue& value)
+    JSValue ScVehicle::colours_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_OBJECT(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
-            vehicle->colours = FromDuk<VehicleColour>(value);
+            vehicle->colours = JSToVehicleColours(ctx, value);
             vehicle->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    DukValue ScVehicle::trackLocation_get() const
+    JSValue ScVehicle::trackLocation_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-        auto vehicle = GetVehicle();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
-            DukObject dukCoords(ctx);
-            dukCoords.Set("x", vehicle->TrackLocation.x);
-            dukCoords.Set("y", vehicle->TrackLocation.y);
-            dukCoords.Set("z", vehicle->TrackLocation.z);
-            dukCoords.Set("direction", vehicle->GetTrackDirection());
-            dukCoords.Set("trackType", EnumValue(vehicle->GetTrackType()));
-            return dukCoords.Take();
+            JSValue obj = JS_NewObject(ctx);
+            JS_SetPropertyStr(ctx, obj, "x", JS_NewInt32(ctx, vehicle->TrackLocation.x));
+            JS_SetPropertyStr(ctx, obj, "y", JS_NewInt32(ctx, vehicle->TrackLocation.y));
+            JS_SetPropertyStr(ctx, obj, "z", JS_NewInt32(ctx, vehicle->TrackLocation.z));
+            JS_SetPropertyStr(ctx, obj, "direction", JS_NewUint32(ctx, vehicle->GetTrackDirection()));
+            JS_SetPropertyStr(ctx, obj, "trackType", JS_NewUint32(ctx, EnumValue(vehicle->GetTrackType())));
+            return obj;
         }
-        return ToDuk(ctx, nullptr);
+        return JS_NULL;
     }
 
-    uint16_t ScVehicle::trackProgress_get() const
+    JSValue ScVehicle::trackProgress_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->track_progress : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->track_progress : 0);
     }
 
-    int32_t ScVehicle::remainingDistance_get() const
+    JSValue ScVehicle::remainingDistance_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->remaining_distance : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewInt32(ctx, vehicle != nullptr ? vehicle->remaining_distance : 0);
     }
 
-    uint8_t ScVehicle::subposition_get() const
+    JSValue ScVehicle::subposition_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? static_cast<uint8_t>(vehicle->TrackSubposition) : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? static_cast<uint8_t>(vehicle->TrackSubposition) : 0);
     }
 
-    uint8_t ScVehicle::poweredAcceleration_get() const
+    JSValue ScVehicle::poweredAcceleration_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->powered_acceleration : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->powered_acceleration : 0);
     }
-    void ScVehicle::poweredAcceleration_set(uint8_t value)
+    JSValue ScVehicle::poweredAcceleration_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->powered_acceleration = value;
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScVehicle::poweredMaxSpeed_get() const
+    JSValue ScVehicle::poweredMaxSpeed_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->speed : 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->speed : 0);
     }
-    void ScVehicle::poweredMaxSpeed_set(uint8_t value)
+    JSValue ScVehicle::poweredMaxSpeed_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->speed = value;
         }
+        return JS_UNDEFINED;
     }
 
-    std::string ScVehicle::status_get() const
+    JSValue ScVehicle::status_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
-            return std::string(VehicleStatusMap[vehicle->status]);
+            return JSFromStdString(ctx, VehicleStatusMap[vehicle->status]);
         }
-        return {};
+        return JS_UNDEFINED;
     }
-    void ScVehicle::status_set(const std::string& value)
+    JSValue ScVehicle::status_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_STR(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->status = VehicleStatusMap[value];
         }
+        return JS_UNDEFINED;
     }
 
-    uint8_t ScVehicle::spin_get() const
+    JSValue ScVehicle::spin_get(JSContext* ctx, JSValue thisVal)
     {
-        auto vehicle = GetVehicle();
-        if (vehicle != nullptr)
-        {
-            return vehicle->spin_sprite;
-        }
-        return 0;
+        auto vehicle = GetVehicle(thisVal);
+        return JS_NewUint32(ctx, vehicle != nullptr ? vehicle->spin_sprite : 0);
     }
-    void ScVehicle::spin_set(const uint8_t value)
+    JSValue ScVehicle::spin_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->spin_sprite = value;
             vehicle->Invalidate();
         }
+        return JS_UNDEFINED;
     }
 
-    std::vector<DukValue> ScVehicle::guests_get() const
+    JSValue ScVehicle::guests_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-        std::vector<DukValue> result;
-        auto vehicle = GetVehicle();
+        auto result = JS_NewArray(ctx);
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             size_t len = 0;
             for (size_t i = 0; i < std::size(vehicle->peep); i++)
             {
                 auto peep = vehicle->peep[i];
-                if (peep.IsNull())
+                if (!peep.IsNull())
                 {
-                    result.push_back(ToDuk(ctx, nullptr));
-                }
-                else
-                {
-                    result.push_back(ToDuk<int32_t>(ctx, peep.ToUnderlying()));
+                    // Set all peep slots between last valid peep and current to NULL (if there were any null peeps).
+                    for (size_t j = len; j < i; j++)
+                    {
+                        JS_SetPropertyInt64(ctx, result, i, JS_NULL);
+                    }
+
+                    JS_SetPropertyInt64(ctx, result, i, JS_NewUint32(ctx, peep.ToUnderlying()));
                     len = i + 1;
                 }
             }
-            result.resize(len);
         }
         return result;
     }
 
-    DukValue ScVehicle::gForces_get() const
+    JSValue ScVehicle::gForces_get(JSContext* ctx, JSValue thisVal)
     {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-        auto vehicle = GetVehicle();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             GForces gForces = vehicle->GetGForces();
-            return ToDuk<GForces>(ctx, gForces);
+            JSValue obj = JS_NewObject(ctx);
+            JS_SetPropertyStr(ctx, obj, "lateralG", JS_NewInt32(ctx, gForces.LateralG));
+            JS_SetPropertyStr(ctx, obj, "verticalG", JS_NewInt32(ctx, gForces.VerticalG));
+            return obj;
         }
-        return ToDuk(ctx, nullptr);
+        return JS_NULL;
     }
 
-    void ScVehicle::travelBy(int32_t value)
+    JSValue ScVehicle::travelBy(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        ThrowIfGameStateNotMutable();
-        auto vehicle = GetVehicle();
+        JS_UNPACK_INT32(value, ctx, argv[1]);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {
             vehicle->MoveRelativeDistance(value);
             EntityTweener::Get().RemoveEntity(vehicle);
         }
+        return JS_UNDEFINED;
     }
 
-    void ScVehicle::moveToTrack(int32_t x, int32_t y, int32_t elementIndex)
+    JSValue ScVehicle::moveToTrack(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
     {
-        auto vehicle = GetVehicle();
+        JS_UNPACK_INT32(x, ctx, argv[1]);
+        JS_UNPACK_INT32(y, ctx, argv[2]);
+        JS_UNPACK_INT32(elementIndex, ctx, argv[3]);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+        auto vehicle = GetVehicle(thisVal);
         if (vehicle == nullptr)
-            return;
+            return JS_UNDEFINED;
 
         CoordsXY coords = TileCoordsXY(x, y).ToCoordsXY();
         auto el = MapGetNthElementAt(coords, elementIndex);
         if (el == nullptr)
-            return;
+            return JS_UNDEFINED;
 
         auto origin = GetTrackSegmentOrigin(CoordsXYE(coords, el));
         if (!origin)
-            return;
+            return JS_UNDEFINED;
 
         const auto& trackType = el->AsTrack()->GetTrackType();
         const auto& ted = GetTrackElementDescriptor(trackType);
@@ -582,6 +615,7 @@ namespace OpenRCT2::Scripting
 
         vehicle->UpdateTrackChange();
         EntityTweener::Get().RemoveEntity(vehicle);
+        return JS_UNDEFINED;
     }
 } // namespace OpenRCT2::Scripting
 

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "../../../entity/EntityTweener.h"
     #include "../../../ride/Ride.h"
@@ -19,91 +19,88 @@
 
 namespace OpenRCT2::Scripting
 {
-    class ScVehicle : public ScEntity
+    class ScVehicle final : public ScEntity
     {
     public:
-        ScVehicle(EntityId id);
-
-        static void Register(duk_context* ctx);
+        static void AddFuncs(JSContext* ctx, JSValue obj);
 
     private:
-        Vehicle* GetVehicle() const;
+        static Vehicle* GetVehicle(JSValue thisVal);
 
-        ObjectEntryIndex rideObject_get() const;
-        void rideObject_set(ObjectEntryIndex value);
+        static JSValue rideObject_get(JSContext* ctx, JSValue thisVal);
+        static JSValue rideObject_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t vehicleObject_get() const;
-        void vehicleObject_set(uint8_t value);
+        static JSValue vehicleObject_get(JSContext* ctx, JSValue thisVal);
+        static JSValue vehicleObject_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t spriteType_get() const;
-        void spriteType_set(uint8_t value);
+        static JSValue spriteType_get(JSContext* ctx, JSValue thisVal);
+        static JSValue spriteType_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        int32_t ride_get() const;
-        void ride_set(int32_t value);
+        static JSValue ride_get(JSContext* ctx, JSValue thisVal);
+        static JSValue ride_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t numSeats_get() const;
-        void numSeats_set(uint8_t value);
+        static JSValue numSeats_get(JSContext* ctx, JSValue thisVal);
+        static JSValue numSeats_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        DukValue nextCarOnTrain_get() const;
-        void nextCarOnTrain_set(DukValue value);
+        static JSValue nextCarOnTrain_get(JSContext* ctx, JSValue thisVal);
+        static JSValue nextCarOnTrain_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        DukValue previousCarOnRide_get() const;
-        void previousCarOnRide_set(DukValue value);
+        static JSValue previousCarOnRide_get(JSContext* ctx, JSValue thisVal);
+        static JSValue previousCarOnRide_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        DukValue nextCarOnRide_get() const;
-        void nextCarOnRide_set(DukValue value);
+        static JSValue nextCarOnRide_get(JSContext* ctx, JSValue thisVal);
+        static JSValue nextCarOnRide_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        StationIndex::UnderlyingType currentStation_get() const;
-        void currentStation_set(StationIndex::UnderlyingType value);
+        static JSValue currentStation_get(JSContext* ctx, JSValue thisVal);
+        static JSValue currentStation_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint16_t mass_get() const;
-        void mass_set(uint16_t value);
+        static JSValue mass_get(JSContext* ctx, JSValue thisVal);
+        static JSValue mass_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        int32_t acceleration_get() const;
-        void acceleration_set(int32_t value);
+        static JSValue acceleration_get(JSContext* ctx, JSValue thisVal);
+        static JSValue acceleration_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        int32_t velocity_get() const;
-        void velocity_set(int32_t value);
+        static JSValue velocity_get(JSContext* ctx, JSValue thisVal);
+        static JSValue velocity_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t bankRotation_get() const;
-        void bankRotation_set(uint8_t value);
+        static JSValue bankRotation_get(JSContext* ctx, JSValue thisVal);
+        static JSValue bankRotation_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
         template<uint32_t flag>
-        bool flag_get() const;
+        static JSValue flag_get(JSContext* ctx, JSValue thisVal);
         template<uint32_t flag>
-        void flag_set(bool value);
+        static JSValue flag_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        DukValue colours_get() const;
-        void colours_set(const DukValue& value);
+        static JSValue colours_get(JSContext* ctx, JSValue thisVal);
+        static JSValue colours_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        DukValue trackLocation_get() const;
-        void trackLocation_set(const DukValue& value);
+        static JSValue trackLocation_get(JSContext* ctx, JSValue thisVal);
 
-        uint16_t trackProgress_get() const;
+        static JSValue trackProgress_get(JSContext* ctx, JSValue thisVal);
 
-        int32_t remainingDistance_get() const;
+        static JSValue remainingDistance_get(JSContext* ctx, JSValue thisVal);
 
-        uint8_t subposition_get() const;
+        static JSValue subposition_get(JSContext* ctx, JSValue thisVal);
 
-        uint8_t poweredAcceleration_get() const;
-        void poweredAcceleration_set(uint8_t value);
+        static JSValue poweredAcceleration_get(JSContext* ctx, JSValue thisVal);
+        static JSValue poweredAcceleration_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t poweredMaxSpeed_get() const;
-        void poweredMaxSpeed_set(uint8_t value);
+        static JSValue poweredMaxSpeed_get(JSContext* ctx, JSValue thisVal);
+        static JSValue poweredMaxSpeed_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        std::string status_get() const;
-        void status_set(const std::string& value);
+        static JSValue status_get(JSContext* ctx, JSValue thisVal);
+        static JSValue status_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        uint8_t spin_get() const;
-        void spin_set(uint8_t value);
+        static JSValue spin_get(JSContext* ctx, JSValue thisVal);
+        static JSValue spin_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
-        std::vector<DukValue> guests_get() const;
+        static JSValue guests_get(JSContext* ctx, JSValue thisVal);
 
-        DukValue gForces_get() const;
+        static JSValue gForces_get(JSContext* ctx, JSValue thisVal);
 
-        void travelBy(int32_t value);
+        static JSValue travelBy(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
 
-        void moveToTrack(int32_t x, int32_t y, int32_t elementIndex);
+        static JSValue moveToTrack(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
     };
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/ride/ScRide.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.hpp
@@ -9,17 +9,15 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
-
     #include "../../../Context.h"
     #include "../../../ride/Ride.h"
-    #include "../../Duktape.hpp"
     #include "../../ScriptEngine.h"
     #include "../object/ScObject.hpp"
     #include "ScRideStation.hpp"
 
 namespace OpenRCT2::Scripting
 {
+#ifdef ENABLE_SCRIPTING
     template<>
     inline DukValue ToDuk(duk_context* ctx, const TrackColour& value)
     {
@@ -39,29 +37,31 @@ namespace OpenRCT2::Scripting
         result.supports = AsOrDefault(s["supports"], 0);
         return result;
     }
+#endif
 
-    template<>
-    inline DukValue ToDuk(duk_context* ctx, const VehicleColour& value)
+#ifdef ENABLE_SCRIPTING_REFACTOR
+    inline JSValue ToJSValue(JSContext* ctx, const VehicleColour& value)
     {
-        DukObject obj(ctx);
-        obj.Set("body", value.Body);
-        obj.Set("trim", value.Trim);
-        obj.Set("ternary", value.Tertiary);
-        obj.Set("tertiary", value.Tertiary);
-        return obj.Take();
+        JSValue obj = JS_NewObject(ctx);
+        JS_SetPropertyStr(ctx, obj, "body", JS_NewInt32(ctx, value.Body));
+        JS_SetPropertyStr(ctx, obj, "trim", JS_NewInt32(ctx, value.Trim));
+        JS_SetPropertyStr(ctx, obj, "ternary", JS_NewInt32(ctx, value.Tertiary)); // backwards compatible typo
+        JS_SetPropertyStr(ctx, obj, "tertiary", JS_NewInt32(ctx, value.Tertiary));
+        return obj;
     }
 
-    template<>
-    inline VehicleColour FromDuk(const DukValue& s)
+    inline VehicleColour JSToVehicleColours(JSContext* ctx, JSValue val)
     {
         VehicleColour result{};
-        result.Body = AsOrDefault(s["body"], 0);
-        result.Trim = AsOrDefault(s["trim"], 0);
-        result.Tertiary = AsOrDefault(s["ternary"], 0);
-        result.Tertiary = AsOrDefault<int32_t>(s["tertiary"], result.Tertiary);
+        result.Body = AsOrDefault(ctx, val, "body", 0);
+        result.Trim = AsOrDefault(ctx, val, "trim", 0);
+        result.Tertiary = AsOrDefault(ctx, val, "ternary", 0); // backwards compatible typo
+        result.Tertiary = AsOrDefault(ctx, val, "tertiary", static_cast<uint32_t>(result.Tertiary));
         return result;
     }
+#endif
 
+#ifdef ENABLE_SCRIPTING
     class ScRide
     {
     private:
@@ -201,6 +201,6 @@ namespace OpenRCT2::Scripting
     public:
         static void Register(duk_context* ctx);
     };
+#endif
 } // namespace OpenRCT2::Scripting
 
-#endif


### PR DESCRIPTION
Might do the rest of the entities in this branch too, due to the dependency.

- [x] `ScBalloon`
- [x] `ScEntity`
- [x] `ScGuest`
- [x] `ScLitter`
- [x] `ScMoneyEffect`
- [x] `ScParticle`
- [x] `ScPeep`
- [x] `ScStaff`
- [x] `ScVehicle`