### PR TITLE
Port ScDate to QuickJS

### DIFF
--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -453,6 +453,7 @@ ScCheats Scripting::gScCheats;
 ScConfiguration Scripting::gScConfiguration;
 ScConsole Scripting::gScConsole;
 ScContext Scripting::gScContext;
+ScDate Scripting::gScDate;
 ScDisposable Scripting::gScDisposable;
 ScMap Scripting::gScMap;
 ScNetwork Scripting::gScNetwork;
@@ -472,7 +473,7 @@ void ScriptEngine::RegisterClasses(JSContext* ctx)
     gScConfiguration.Register(ctx);
     gScConsole.Register(ctx);
     gScContext.Register(ctx);
-    // ScDate::Register(ctx);
+    gScDate.Register(ctx);
     gScDisposable.Register(ctx);
     gScMap.Register(ctx);
     gScNetwork.Register(ctx);
@@ -541,7 +542,7 @@ void ScriptEngine::InitialiseContext(JSContext* ctx) const
     // dukglue_register_global(ctx, std::make_shared<ScClimate>(), "climate");
     JS_SetPropertyStr(ctx, glb, "console", gScConsole.New(ctx, _console));
     JS_SetPropertyStr(ctx, glb, "context", gScContext.New(ctx));
-    // dukglue_register_global(ctx, std::make_shared<ScDate>(), "date");
+    JS_SetPropertyStr(ctx, glb, "date", gScDate.New(ctx));
     JS_SetPropertyStr(ctx, glb, "map", gScMap.New(ctx));
     JS_SetPropertyStr(ctx, glb, "network", gScNetwork.New(ctx));
     JS_SetPropertyStr(ctx, glb, "park", gScPark.New(ctx));

--- a/src/openrct2/scripting/bindings/world/ScDate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScDate.hpp
@@ -9,80 +9,91 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "../../../Context.h"
     #include "../../../Date.h"
     #include "../../../Game.h"
     #include "../../../GameState.h"
-    #include "../../Duktape.hpp"
     #include "../../ScriptEngine.h"
 
 namespace OpenRCT2::Scripting
 {
-    class ScDate
+    class ScDate;
+    extern ScDate gScDate;
+    class ScDate final : public ScBase
     {
+        static JSValue monthsElapsed_get(JSContext* ctx, JSValue)
+        {
+            const auto& date = GetDate();
+            return JS_NewInt32(ctx, date.GetMonthsElapsed());
+        }
+
+        static JSValue monthsElapsed_set(JSContext* ctx, JSValue, JSValue jsValue)
+        {
+            JS_UNPACK_UINT32(value, ctx, jsValue);
+            OpenRCT2::getGameState().date = Date{ value, GetDate().GetMonthTicks() };
+            return JS_UNDEFINED;
+        }
+
+        static JSValue monthProgress_get(JSContext* ctx, JSValue)
+        {
+            const auto& date = GetDate();
+            return JS_NewUint32(ctx, date.GetMonthTicks());
+        }
+
+        static JSValue monthProgress_set(JSContext* ctx, JSValue, JSValue jsValue)
+        {
+            JS_UNPACK_INT32(value, ctx, jsValue);
+            OpenRCT2::getGameState().date = Date{ GetDate().GetMonthsElapsed(), static_cast<uint16_t>(value) };
+            return JS_UNDEFINED;
+        }
+
+        static JSValue yearsElapsed_get(JSContext* ctx, JSValue)
+        {
+            const auto& date = GetDate();
+            return JS_NewUint32(ctx, date.GetYear());
+        }
+
+        static JSValue ticksElapsed_get(JSContext* ctx, JSValue)
+        {
+            return JS_NewUint32(ctx, getGameState().currentTicks);
+        }
+
+        static JSValue day_get(JSContext* ctx, JSValue)
+        {
+            return JS_NewInt32(ctx, getGameState().date.GetDay() + 1);
+        }
+
+        static JSValue month_get(JSContext* ctx, JSValue)
+        {
+            return JS_NewInt32(ctx, getGameState().date.GetMonth());
+        }
+
+        static JSValue year_get(JSContext* ctx, JSValue)
+        {
+            return JS_NewInt32(ctx, getGameState().date.GetYear() + 1);
+        }
+
     public:
-        static void Register(duk_context* ctx)
+        JSValue New(JSContext* ctx)
         {
-            dukglue_register_property(ctx, &ScDate::monthsElapsed_get, &ScDate::monthsElapsed_set, "monthsElapsed");
-            dukglue_register_property(ctx, &ScDate::monthProgress_get, &ScDate::monthProgress_set, "monthProgress");
-            dukglue_register_property(ctx, &ScDate::yearsElapsed_get, nullptr, "yearsElapsed");
-            dukglue_register_property(ctx, &ScDate::ticksElapsed_get, nullptr, "ticksElapsed");
-            dukglue_register_property(ctx, &ScDate::day_get, nullptr, "day");
-            dukglue_register_property(ctx, &ScDate::month_get, nullptr, "month");
-            dukglue_register_property(ctx, &ScDate::year_get, nullptr, "year");
+            static constexpr JSCFunctionListEntry funcs[] = {
+                JS_CGETSET_DEF("monthsElapsed", ScDate::monthsElapsed_get, ScDate::monthsElapsed_set),
+                JS_CGETSET_DEF("monthProgress", ScDate::monthProgress_get, ScDate::monthProgress_set),
+                JS_CGETSET_DEF("yearsElapsed", ScDate::yearsElapsed_get, nullptr),
+                JS_CGETSET_DEF("ticksElapsed", ScDate::ticksElapsed_get, nullptr),
+                JS_CGETSET_DEF("day", ScDate::day_get, nullptr),
+                JS_CGETSET_DEF("month", ScDate::month_get, nullptr),
+                JS_CGETSET_DEF("year", ScDate::year_get, nullptr),
+            };
+
+            return MakeWithOpaque(ctx, funcs, nullptr);
         }
 
-    private:
-        int32_t monthsElapsed_get() const
+        void Register(JSContext* ctx)
         {
-            const auto& date = GetDate();
-            return date.GetMonthsElapsed();
-        }
-
-        void monthsElapsed_set(uint32_t value)
-        {
-            ThrowIfGameStateNotMutable();
-            getGameState().date = Date{ value, GetDate().GetMonthTicks() };
-        }
-
-        uint32_t monthProgress_get() const
-        {
-            const auto& date = GetDate();
-            return date.GetMonthTicks();
-        }
-
-        void monthProgress_set(int32_t value)
-        {
-            ThrowIfGameStateNotMutable();
-            getGameState().date = Date{ GetDate().GetMonthsElapsed(), static_cast<uint16_t>(value) };
-        }
-
-        uint32_t yearsElapsed_get() const
-        {
-            const auto& date = GetDate();
-            return date.GetYear();
-        }
-
-        uint32_t ticksElapsed_get() const
-        {
-            return getGameState().currentTicks;
-        }
-
-        int32_t day_get() const
-        {
-            return getGameState().date.GetDay() + 1;
-        }
-
-        int32_t month_get() const
-        {
-            return getGameState().date.GetMonth();
-        }
-
-        int32_t year_get() const
-        {
-            return getGameState().date.GetYear() + 1;
+            RegisterBaseStr(ctx, "Date");
         }
     };
 } // namespace OpenRCT2::Scripting


### PR DESCRIPTION
@mrmbernardi I used this plugin to test:
```js
function testDateAPI()
{
	console.log("Date API Test Plugin loaded.");
	console.log("ticks: " + date.ticksElapsed);
	console.log("months before: " + date.monthsElapsed);
	date.monthsElapsed += 3;
	console.log("months after: " + date.monthsElapsed);
	console.log("monthProgress before: " + date.monthProgress);
	date.monthProgress += 120;
	console.log("monthProgress after: " + date.monthProgress);
	console.log("years: " + date.yearsElapsed);
	console.log("day: " + date.day);
	console.log("month: " + date.month);
	console.log("year: " + date.year);
}

registerPlugin({
	name: 'date quickjs test',
	version: '1',
	authors: ['Tupaschoal'],
	type: 'local',
	licence: 'MIT',
	targetApiVersion: 70,
	main: testDateAPI
});
```
And the output was the same on a release and this branch when loading Six Flags Over Texas' SC6:

```
[date quickjs test] Loaded
[date quickjs test] Started
'Date API Test Plugin loaded.'
'ticks: 844'
'months before: 0'
'months after: 3'
'monthProgress before: 4'
'monthProgress after: 124'
'years: 0'
'day: 1'
'month: 3'
'year: 1'
```