### PR TITLE
Port ScClimate to QuickJS

### DIFF
--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -467,6 +467,8 @@ void ScriptEngine::Initialise()
 JSRuntime* ScriptEngine::_runtime = nullptr;
 ScAward Scripting::gScAward;
 ScCheats Scripting::gScCheats;
+ScClimate Scripting::gScClimate;
+ScWeatherState Scripting::gScWeatherState;
 ScConfiguration Scripting::gScConfiguration;
 ScConsole Scripting::gScConsole;
 ScContext Scripting::gScContext;
@@ -492,8 +494,8 @@ void ScriptEngine::RegisterClasses(JSContext* ctx)
     // TODO (mber) register JS Classes
     gScAward.Register(ctx);
     gScCheats.Register(ctx);
-    // ScClimate::Register(ctx);
-    // ScClimateState::Register(ctx);
+    gScClimate.Register(ctx);
+    gScWeatherState.Register(ctx);
     gScConfiguration.Register(ctx);
     gScConsole.Register(ctx);
     gScContext.Register(ctx);
@@ -555,7 +557,7 @@ void ScriptEngine::InitialiseContext(JSContext* ctx) const
 {
     JSValue glb = JS_GetGlobalObject(ctx);
     JS_SetPropertyStr(ctx, glb, "cheats", gScCheats.New(ctx));
-    // dukglue_register_global(ctx, std::make_shared<ScClimate>(), "climate");
+    JS_SetPropertyStr(ctx, glb, "climate", gScClimate.New(ctx));
     JS_SetPropertyStr(ctx, glb, "console", gScConsole.New(ctx, _console));
     JS_SetPropertyStr(ctx, glb, "context", gScContext.New(ctx));
     JS_SetPropertyStr(ctx, glb, "date", gScDate.New(ctx));

--- a/src/openrct2/scripting/bindings/world/ScClimate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScClimate.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING_REFACTOR
 
     #include "../../../Context.h"
     #include "../../../GameState.h"
@@ -17,44 +17,60 @@
     #include "../../../object/ClimateObject.h"
     #include "../../../object/ObjectManager.h"
     #include "../../../world/Climate.h"
-    #include "../../Duktape.hpp"
     #include "../../ScriptEngine.h"
 
 namespace OpenRCT2::Scripting
 {
-    class ScWeatherState
+    class ScWeatherState;
+    extern ScWeatherState gScWeatherState;
+    class ScWeatherState final : public ScBase
     {
     private:
-        std::string _weather;
-        int8_t _temperature;
+        using OpaqueWeatherStateData = struct
+        {
+            std::string weather;
+            int8_t temperature;
+        };
+
+        static JSValue weather_get(JSContext* ctx, JSValue thisVal)
+        {
+            return JS_NewString(ctx, gScWeatherState.GetOpaque<OpaqueWeatherStateData*>(thisVal)->weather.c_str());
+        }
+
+        static JSValue temperature_get(JSContext* ctx, JSValue thisVal)
+        {
+            return JS_NewInt32(ctx, gScWeatherState.GetOpaque<OpaqueWeatherStateData*>(thisVal)->temperature);
+        }
 
     public:
-        ScWeatherState(std::string weather, int8_t temperature)
-            : _weather(weather)
-            , _temperature(temperature)
+        JSValue New(JSContext* ctx, const std::string& weather, int8_t temperature)
         {
+            static constexpr JSCFunctionListEntry funcs[] = {
+                JS_CGETSET_DEF("weather", ScWeatherState::weather_get, nullptr),
+                JS_CGETSET_DEF("temperature", ScWeatherState::temperature_get, nullptr),
+            };
+
+            return MakeWithOpaque(ctx, funcs, new OpaqueWeatherStateData{ weather, temperature });
         }
 
-        std::string weather_get() const
+        void Register(JSContext* ctx)
         {
-            return _weather;
+            RegisterBaseStr(ctx, "WeatherState");
         }
 
-        int8_t temperature_get() const
+        void Finalize(JSRuntime*, JSValue thisVal)
         {
-            return _temperature;
-        }
-
-        static void Register(duk_context* ctx)
-        {
-            dukglue_register_property(ctx, &ScWeatherState::weather_get, nullptr, "weather");
-            dukglue_register_property(ctx, &ScWeatherState::temperature_get, nullptr, "temperature");
+            OpaqueWeatherStateData* data = gScWeatherState.GetOpaque<OpaqueWeatherStateData*>(thisVal);
+            if (data)
+                delete data;
         }
     };
 
-    class ScClimate
+    class ScClimate;
+    extern ScClimate gScClimate;
+    class ScClimate final : public ScBase
     {
-    public:
+    private:
         static std::string WeatherTypeToString(WeatherType token)
         {
             switch (token)
@@ -83,35 +99,45 @@ namespace OpenRCT2::Scripting
             return {};
         }
 
-        std::string type_get() const
+        static JSValue type_get(JSContext* ctx, JSValue)
         {
-            auto& objManager = GetContext()->GetObjectManager();
+            auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
             auto* climateObj = objManager.GetLoadedObject<ClimateObject>(0);
             if (climateObj == nullptr)
-                return {};
+                return JS_UNDEFINED;
 
-            return climateObj->getScriptName();
+            return JS_NewString(ctx, climateObj->getScriptName().c_str());
         }
 
-        std::shared_ptr<ScWeatherState> current_get() const
+        static JSValue current_get(JSContext* ctx, JSValue)
         {
             auto& gameState = getGameState();
             std::string weatherType = WeatherTypeToString(gameState.weatherCurrent.weatherType);
-            return std::make_shared<ScWeatherState>(weatherType, gameState.weatherCurrent.temperature);
+            return gScWeatherState.New(ctx, weatherType, gameState.weatherCurrent.temperature);
         }
 
-        std::shared_ptr<ScWeatherState> future_get() const
+        static JSValue future_get(JSContext* ctx, JSValue)
         {
             auto& gameState = getGameState();
             std::string weatherType = WeatherTypeToString(gameState.weatherNext.weatherType);
-            return std::make_shared<ScWeatherState>(weatherType, gameState.weatherNext.temperature);
+            return gScWeatherState.New(ctx, weatherType, gameState.weatherCurrent.temperature);
         }
 
-        static void Register(duk_context* ctx)
+    public:
+        JSValue New(JSContext* ctx)
         {
-            dukglue_register_property(ctx, &ScClimate::type_get, nullptr, "type");
-            dukglue_register_property(ctx, &ScClimate::current_get, nullptr, "current");
-            dukglue_register_property(ctx, &ScClimate::future_get, nullptr, "future");
+            static constexpr JSCFunctionListEntry funcs[] = {
+                JS_CGETSET_DEF("type", ScClimate::type_get, nullptr),
+                JS_CGETSET_DEF("current", ScClimate::current_get, nullptr),
+                JS_CGETSET_DEF("future", ScClimate::future_get, nullptr),
+            };
+
+            return MakeWithOpaque(ctx, funcs, nullptr);
+        }
+
+        void Register(JSContext* ctx)
+        {
+            RegisterBaseStr(ctx, "Climate");
         }
     };
 

--- a/src/openrct2/scripting/bindings/world/ScClimate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScClimate.hpp
@@ -104,7 +104,7 @@ namespace OpenRCT2::Scripting
             auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
             auto* climateObj = objManager.GetLoadedObject<ClimateObject>(0);
             if (climateObj == nullptr)
-                return JS_UNDEFINED;
+                return JS_NewString(ctx, {});
 
             return JS_NewString(ctx, climateObj->getScriptName().c_str());
         }


### PR DESCRIPTION
Test plugin:
```js
function main()
{
	console.log("Climate API Test Plugin loaded.");
	console.log("Climate type " + climate.type)
	var currentClimate = climate.current;
	var futureClimate = climate.future;
	console.log("Current climate: weather " + currentClimate.weather + ", temperature " + currentClimate.temperature);
	console.log("Future climate: weather " + futureClimate.weather + ", temperature " + futureClimate.temperature);
	console.log("Climate API Test Plugin testing done.");
}

registerPlugin({
	name: 'climate quickjs test',
	version: '1',
	authors: ['Tupaschoal'],
	type: 'local',
	licence: 'MIT',
	targetApiVersion: 70,
	main: main
});
```

Plugin output (doesn't differ in release and branch):
```
'Climate API Test Plugin loaded.'
'Climate type warm'
'Current climate: weather partiallyCloudy, temperature 17'
'Future climate: weather partiallyCloudy, temperature 17'
'Climate API Test Plugin testing done.'
```